### PR TITLE
chore: update VSCode settings for env file

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,9 @@
     "css.customData": [
         ".vscode/tailwind.json"
     ],
+    "files.associations": {
+        ".env.*": "env"
+    },
     "python.defaultInterpreterPath": "${workspaceFolder}/backend/.venv/bin/python",
     "[python]": {
         "editor.formatOnSave": true,


### PR DESCRIPTION
Add file for .env.* files to use env syntax highlighting.
This improves editor support and readability for environment files.