### PR TITLE
fix(client): update baseUrl to use import.meta.env

### DIFF
--- a/frontend/app/client/client.gen.ts
+++ b/frontend/app/client/client.gen.ts
@@ -14,5 +14,5 @@ import { type Config, type ClientOptions as DefaultClientOptions, createClient, 
 export type CreateClientConfig<T extends DefaultClientOptions = ClientOptions> = (override?: Config<DefaultClientOptions & T>) => Config<Required<DefaultClientOptions> & T>;
 
 export const client = createClient(createConfig<ClientOptions>({
-    baseUrl: process.env.VITE_API_URL
+    baseUrl: import.meta.env.VITE_API_URL,
 }));


### PR DESCRIPTION
Change the baseUrl assignment in client configuration to use
import.meta.env.VITE_API_URL instead of process.env.VITE_API_URL.