### PR TITLE
Fix Docker Compose to use env vars for frontend host and CORS origins

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -36,8 +36,8 @@ services:
     ports:
       - "${SCHOLARK_BACKEND_PORT?Variable not set}:8000"
     environment:
-      - SCHOLARK_FRONTEND_HOST=http://frontend:3000
-      - SCHOLARK_BACKEND_CORS_ORIGINS="http://frontend,http://frontend:3000,https://frontend,https://frontend:3000,http://localhost"
+      - SCHOLARK_FRONTEND_HOST=${SCHOLARK_FRONTEND_HOST?Variable not set}
+      - SCHOLARK_BACKEND_CORS_ORIGINS=${SCHOLARK_BACKEND_CORS_ORIGINS?Variable not set}
       - SCHOLARK_POSTGRES_SERVER=db
       - SCHOLARK_POSTGRES_PORT=5432
       - SCHOLARK_POSTGRES_USER=${SCHOLARK_POSTGRES_USER?Variable not set}


### PR DESCRIPTION
## Summary

- Replace hardcoded Docker-internal URLs (`http://frontend:3000`) with environment variables for `SCHOLARK_FRONTEND_HOST` and `SCHOLARK_BACKEND_CORS_ORIGINS` in `compose.yaml`
- Fixes Slack "View in Scholark" links pointing to unreachable container hostnames
- Fixes CORS origins listing Docker-internal names that browsers never send

Both variables are already defined in `.env` and work out of the box with `docker compose up`.

## Test plan

- [ ] Run `docker compose up` with the existing `.env` and verify the app starts correctly
- [ ] Trigger a Slack notification and verify the "View in Scholark" link uses the correct external URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)