### PR TITLE
Fix empty BACKEND_CORS_ORIGINS validation error

### DIFF
--- a/backend/src/scholark/core/config.py
+++ b/backend/src/scholark/core/config.py
@@ -8,7 +8,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 def parse_cors(v: Any) -> list[str] | str:
     if isinstance(v, str) and not v.startswith("["):
-        return [i.strip() for i in v.split(",")]
+        return [i.strip() for i in v.split(",") if i.strip()]
     if isinstance(v, list | str):
         return v
     raise ValueError(v)


### PR DESCRIPTION
## Summary

- Filter out empty strings in `parse_cors` so that an unset or empty `BACKEND_CORS_ORIGINS` env var produces `[]` instead of `[""]`, which fails Pydantic's `AnyUrl` validation.

## Test plan

- [ ] Run `docker compose up --build` with `SCHOLARK_BACKEND_CORS_ORIGINS` unset or empty and verify the backend starts without validation errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)