### PR TITLE
Group Vite+ Renovate updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -19,6 +19,16 @@
       minimumReleaseAge: null,
     },
     {
+      // Vite+ publishes tightly coupled packages together. Keep the pnpm
+      // catalog aliases in sync so Renovate does not create incompatible
+      // standalone PRs for vite-plus and its Vite/Vitest core aliases.
+      matchDatasources: ["npm"],
+      matchDepNames: ["vite", "vitest", "vite-plus"],
+      groupName: "Vite+ packages",
+      groupSlug: "vite-plus",
+      minimumGroupSize: 2,
+    },
+    {
       matchCategories: ["ci"],
       addLabels: ["ci"],
     },


### PR DESCRIPTION
## Summary
- Group Renovate updates for Vite+ catalog aliases (`vite`, `vitest`, and `vite-plus`)
- Require at least two matching updates so tightly coupled Vite+ packages are updated together instead of creating incompatible standalone PRs

## Context
PRs #750 and #751 failed because Renovate updated `vite` / `@voidzero-dev/vite-plus-core` and `vite-plus` separately. These packages are coupled and need to move together.

## Validation
- `vp dlx -p renovate renovate-config-validator renovate.json5`
- `just lint-markdown` attempted, but existing `frontend/node_modules/**` markdown files fail linting; unrelated to this change.
