### PR TITLE
Make ConferencePublic.created_by_user_id optional

### DIFF
--- a/backend/src/scholark/models.py
+++ b/backend/src/scholark/models.py
@@ -125,7 +125,7 @@ class ConferencePublic(ConferenceBase):
     id: uuid.UUID
     created_at: datetime
     updated_at: datetime
-    created_by_user_id: uuid.UUID
+    created_by_user_id: uuid.UUID | None
 
     tags: list[TagPublic] = Field(default=None)
     milestones: list[ConferenceMilestonePublic]


### PR DESCRIPTION
The DB column is nullable with ondelete=SET NULL, so once a conference
creator is deleted, response validation failed and every conference
read returned 500 for all users. (Review item 1.2)

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 13 in a stack** made with GitButler:
- <kbd>&nbsp;13&nbsp;</kbd> #781 
- <kbd>&nbsp;12&nbsp;</kbd> #780 
- <kbd>&nbsp;11&nbsp;</kbd> #779 
- <kbd>&nbsp;10&nbsp;</kbd> #778 
- <kbd>&nbsp;9&nbsp;</kbd> #777 
- <kbd>&nbsp;8&nbsp;</kbd> #776 
- <kbd>&nbsp;7&nbsp;</kbd> #775 
- <kbd>&nbsp;6&nbsp;</kbd> #774 
- <kbd>&nbsp;5&nbsp;</kbd> #773 
- <kbd>&nbsp;4&nbsp;</kbd> #772 
- <kbd>&nbsp;3&nbsp;</kbd> #771 
- <kbd>&nbsp;2&nbsp;</kbd> #770 
- <kbd>&nbsp;1&nbsp;</kbd> #769 👈 
<!-- GitButler Footer Boundary Bottom -->

