### PR TITLE
Handle milestones explicitly in update_conference's field set

### DIFF
--- a/backend/src/scholark/api/routes/conferences.py
+++ b/backend/src/scholark/api/routes/conferences.py
@@ -144,9 +144,15 @@ def update_conference(
         raise HTTPException(status_code=404, detail="Conference not found")
 
     new_milestones = conference_in.milestones or []
-    conference_in.milestones = None
     update_dict = conference_in.model_dump(exclude_unset=True)
-    update_dict["updated_at"] = datetime.now(UTC)
+    # milestones is a relationship, not a column; it is applied separately below.
+    update_dict.pop("milestones", None)
+
+    fields_changed = any(getattr(conference, field) != value for field, value in update_dict.items())
+    milestones_changed = [(m.name, m.date, m.time) for m in conference.milestones] != [
+        (m.name, m.date, m.time) for m in new_milestones
+    ]
+
     conference.sqlmodel_update(update_dict)
     for milestone in conference.milestones:
         session.delete(milestone)
@@ -155,6 +161,8 @@ def update_conference(
         ConferenceMilestone.model_validate(milestone, update={"conference_id": conference.id})
         for milestone in new_milestones
     ]
+    if fields_changed or milestones_changed:
+        conference.updated_at = datetime.now(UTC)
     session.add(conference)
     session.commit()
     session.refresh(conference)


### PR DESCRIPTION
Assigning conference_in.milestones = None marked the field as set, so
model_dump(exclude_unset=True) contained milestones=None and only
avoided clobbering the relationship because sqlmodel_update ignores
non-column keys. Pop the key from the dict instead. Also stop bumping
updated_at when the request changes nothing. (Review item 2.5)

<!-- GitButler Footer Boundary Top -->
---
This is **part 5 of 13 in a stack** made with GitButler:
- <kbd>&nbsp;13&nbsp;</kbd> #781 
- <kbd>&nbsp;12&nbsp;</kbd> #780 
- <kbd>&nbsp;11&nbsp;</kbd> #779 
- <kbd>&nbsp;10&nbsp;</kbd> #778 
- <kbd>&nbsp;9&nbsp;</kbd> #777 
- <kbd>&nbsp;8&nbsp;</kbd> #776 
- <kbd>&nbsp;7&nbsp;</kbd> #775 
- <kbd>&nbsp;6&nbsp;</kbd> #774 
- <kbd>&nbsp;5&nbsp;</kbd> #773 👈 
- <kbd>&nbsp;4&nbsp;</kbd> #772 
- <kbd>&nbsp;3&nbsp;</kbd> #771 
- <kbd>&nbsp;2&nbsp;</kbd> #770 
- <kbd>&nbsp;1&nbsp;</kbd> #769 
<!-- GitButler Footer Boundary Bottom -->

