### PR TITLE
Update conference milestones in place instead of delete-and-recreate

### DIFF
--- a/backend/src/scholark/api/routes/conferences.py
+++ b/backend/src/scholark/api/routes/conferences.py
@@ -143,24 +143,49 @@ def update_conference(
     if not conference:
         raise HTTPException(status_code=404, detail="Conference not found")
 
-    new_milestones = conference_in.milestones or []
     update_dict = conference_in.model_dump(exclude_unset=True)
-    # milestones is a relationship, not a column; it is applied separately below.
-    update_dict.pop("milestones", None)
+    # milestones is a relationship, not a column; it is applied separately
+    # below, and only when the client actually sent the key (an omitted
+    # milestones field leaves the existing milestones untouched).
+    milestones_provided = update_dict.pop("milestones", None) is not None
 
     fields_changed = any(getattr(conference, field) != value for field, value in update_dict.items())
-    milestones_changed = [(m.name, m.date, m.time) for m in conference.milestones] != [
-        (m.name, m.date, m.time) for m in new_milestones
-    ]
-
     conference.sqlmodel_update(update_dict)
-    for milestone in conference.milestones:
-        session.delete(milestone)
 
-    conference.milestones = [
-        ConferenceMilestone.model_validate(milestone, update={"conference_id": conference.id})
-        for milestone in new_milestones
-    ]
+    # Update milestones in place by id: milestones with a known id keep their
+    # id and any field the client does not send (such as time); milestones
+    # without a matching id are created; the rest are deleted.
+    milestones_changed = False
+    if milestones_provided:
+        new_milestones = conference_in.milestones or []
+        existing_by_id = {milestone.id: milestone for milestone in conference.milestones}
+        matched_ids: set[UUID] = set()
+        added: list[ConferenceMilestone] = []
+        for milestone_in in new_milestones:
+            existing = existing_by_id.get(milestone_in.id) if milestone_in.id is not None else None
+            if existing is None:
+                added.append(
+                    ConferenceMilestone(
+                        name=milestone_in.name,
+                        date=milestone_in.date,
+                        time=milestone_in.time,
+                        conference_id=conference.id,
+                    ),
+                )
+                milestones_changed = True
+            else:
+                matched_ids.add(existing.id)
+                milestone_update = milestone_in.model_dump(exclude_unset=True, exclude={"id"})
+                if any(getattr(existing, field) != value for field, value in milestone_update.items()):
+                    existing.sqlmodel_update(milestone_update)
+                    milestones_changed = True
+
+        for milestone in conference.milestones:
+            if milestone.id not in matched_ids:
+                session.delete(milestone)
+                milestones_changed = True
+        conference.milestones = [m for m in conference.milestones if m.id in matched_ids] + added
+
     if fields_changed or milestones_changed:
         conference.updated_at = datetime.now(UTC)
     session.add(conference)

--- a/backend/src/scholark/models.py
+++ b/backend/src/scholark/models.py
@@ -82,6 +82,17 @@ class ConferenceMilestoneCreate(ConferenceMilestoneBase):
     pass
 
 
+class ConferenceMilestoneUpdate(ConferenceMilestoneBase):
+    """Milestone payload for conference updates.
+
+    Carrying the id lets the server update the existing row in place instead
+    of deleting and recreating all milestones; milestones without an id are
+    created.
+    """
+
+    id: uuid.UUID | None = Field(default=None)
+
+
 class ConferenceMilestone(ConferenceMilestoneBase, table=True):
     id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
     conference_id: uuid.UUID = Field(foreign_key="conference.id", ondelete="CASCADE")
@@ -107,7 +118,7 @@ class ConferenceCreate(ConferenceBase):
 
 
 class ConferenceUpdate(ConferenceBase):
-    milestones: list[ConferenceMilestoneCreate] | None = Field(default=None)
+    milestones: list[ConferenceMilestoneUpdate] | None = Field(default=None)
 
 
 class Conference(ConferenceBase, table=True):


### PR DESCRIPTION
The PUT handler deleted and recreated every milestone on each edit, so
milestone ids churned on every save and any field the client did not
resubmit (such as the optional time) was silently lost. Accept an
optional id per milestone (ConferenceMilestoneUpdate), update matching
rows in place preserving unsent fields, create milestones without an
id, and delete only the ones omitted from the request.
(Review item 3.5, backend half)

<!-- GitButler Footer Boundary Top -->
---
This is **part 6 of 13 in a stack** made with GitButler:
- <kbd>&nbsp;13&nbsp;</kbd> #781 
- <kbd>&nbsp;12&nbsp;</kbd> #780 
- <kbd>&nbsp;11&nbsp;</kbd> #779 
- <kbd>&nbsp;10&nbsp;</kbd> #778 
- <kbd>&nbsp;9&nbsp;</kbd> #777 
- <kbd>&nbsp;8&nbsp;</kbd> #776 
- <kbd>&nbsp;7&nbsp;</kbd> #775 
- <kbd>&nbsp;6&nbsp;</kbd> #774 👈 
- <kbd>&nbsp;5&nbsp;</kbd> #773 
- <kbd>&nbsp;4&nbsp;</kbd> #772 
- <kbd>&nbsp;3&nbsp;</kbd> #771 
- <kbd>&nbsp;2&nbsp;</kbd> #770 
- <kbd>&nbsp;1&nbsp;</kbd> #769 
<!-- GitButler Footer Boundary Bottom -->

