### PR TITLE
Enforce User.disabled at login and token validation

### DIFF
--- a/backend/src/scholark/api/deps.py
+++ b/backend/src/scholark/api/deps.py
@@ -48,6 +48,13 @@ def get_current_user(session: SessionDep, token: TokenDep) -> User:
             status_code=status.HTTP_404_NOT_FOUND,
             detail="User not found",
         )
+    if user.disabled:
+        # 401 so clients treat the token as no longer valid and re-authenticate.
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Inactive user",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
 
     return user
 

--- a/backend/src/scholark/api/routes/login.py
+++ b/backend/src/scholark/api/routes/login.py
@@ -22,6 +22,8 @@ def login_access_token(
     )
     if not user:
         raise HTTPException(status_code=400, detail="Incorrect username or password")
+    if user.disabled:
+        raise HTTPException(status_code=400, detail="Inactive user")
     return Token(access_token=security.create_access_token(user.id))
 
 


### PR DESCRIPTION
The disabled flag existed but was checked nowhere, so disabling a user
had no effect. Reject disabled users at login with 400 and reject
their existing tokens with 401 so clients re-authenticate.
(Review item 1.6)

<!-- GitButler Footer Boundary Top -->
---
This is **part 8 of 13 in a stack** made with GitButler:
- <kbd>&nbsp;13&nbsp;</kbd> #781 
- <kbd>&nbsp;12&nbsp;</kbd> #780 
- <kbd>&nbsp;11&nbsp;</kbd> #779 
- <kbd>&nbsp;10&nbsp;</kbd> #778 
- <kbd>&nbsp;9&nbsp;</kbd> #777 
- <kbd>&nbsp;8&nbsp;</kbd> #776 👈 
- <kbd>&nbsp;7&nbsp;</kbd> #775 
- <kbd>&nbsp;6&nbsp;</kbd> #774 
- <kbd>&nbsp;5&nbsp;</kbd> #773 
- <kbd>&nbsp;4&nbsp;</kbd> #772 
- <kbd>&nbsp;3&nbsp;</kbd> #771 
- <kbd>&nbsp;2&nbsp;</kbd> #770 
- <kbd>&nbsp;1&nbsp;</kbd> #769 
<!-- GitButler Footer Boundary Bottom -->

