### PR TITLE
Return 404 from read_user_by_id when the user does not exist

### DIFF
--- a/backend/src/scholark/api/routes/users.py
+++ b/backend/src/scholark/api/routes/users.py
@@ -103,6 +103,8 @@ def read_user_by_id(
             status_code=403,
             detail="The user doesn't have enough privileges",
         )
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
     return user
 
 


### PR DESCRIPTION
A superuser requesting a missing user id got None validated through
response_model=UserPublic, i.e. a ResponseValidationError 500.
(Review item 2.3)

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 7 in a stack** made with GitButler:
- <kbd>&nbsp;7&nbsp;</kbd> #781 
- <kbd>&nbsp;6&nbsp;</kbd> #780 
- <kbd>&nbsp;5&nbsp;</kbd> #779 
- <kbd>&nbsp;4&nbsp;</kbd> #778 
- <kbd>&nbsp;3&nbsp;</kbd> #777 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #796 
- <kbd>&nbsp;1&nbsp;</kbd> #795 
<!-- GitButler Footer Boundary Bottom -->

