### PR TITLE
Enable CORS middleware for the configured origins

### DIFF
--- a/backend/src/scholark/main.py
+++ b/backend/src/scholark/main.py
@@ -3,6 +3,7 @@ from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.routing import APIRoute
 from sqlmodel import Session, select
 
@@ -48,6 +49,14 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
+if settings.all_cors_origins:
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=settings.all_cors_origins,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
 
 app.include_router(api_router, prefix=settings.API_V1_STR)
 


### PR DESCRIPTION
Settings.all_cors_origins and the SCHOLARK_BACKEND_CORS_ORIGINS
plumbing existed but main.py never added CORSMiddleware, so the
configuration had no effect. (Review item 2.4)

<!-- GitButler Footer Boundary Top -->
---
This is **part 4 of 7 in a stack** made with GitButler:
- <kbd>&nbsp;7&nbsp;</kbd> #781 
- <kbd>&nbsp;6&nbsp;</kbd> #780 
- <kbd>&nbsp;5&nbsp;</kbd> #779 
- <kbd>&nbsp;4&nbsp;</kbd> #778 👈 
- <kbd>&nbsp;3&nbsp;</kbd> #777 
- <kbd>&nbsp;2&nbsp;</kbd> #796 
- <kbd>&nbsp;1&nbsp;</kbd> #795 
<!-- GitButler Footer Boundary Bottom -->

