### PR TITLE
Fix smaller backend issues from the code review

### DIFF
--- a/.env
+++ b/.env
@@ -32,3 +32,5 @@ SCHOLARK_DB_AUTO_MIGRATE=true
 # Slack notification
 # SCHOLARK_SLACK_BOT_TOKEN=xoxb-
 # SCHOLARK_SLACK_CHANNEL_ID=C
+# IANA timezone used to compute "today" for milestone reminders (default: UTC)
+# SCHOLARK_REMINDER_TIMEZONE=Asia/Tokyo

--- a/backend/scripts/startup.sh
+++ b/backend/scripts/startup.sh
@@ -11,14 +11,9 @@ if [ "$AUTO_MIGRATE" = "true" ]; then
 
     # Run alembic migrations
     # Using alembic directly since we're already in the container with dependencies installed
+    # set -e aborts the script if this fails
     alembic upgrade head
-
-    if [ $? -eq 0 ]; then
-        echo "Database migrations completed successfully."
-    else
-        echo "Error: Database migrations failed!"
-        exit 1
-    fi
+    echo "Database migrations completed successfully."
 else
     echo "Auto-migration is disabled. Skipping database migrations."
     echo "Please ensure migrations have been run manually before starting the backend."

--- a/backend/src/scholark/api/deps.py
+++ b/backend/src/scholark/api/deps.py
@@ -1,8 +1,9 @@
+import uuid
 from collections.abc import Generator
 from typing import Annotated
 
 import jwt
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends, HTTPException, Query, status
 from fastapi.security import OAuth2PasswordBearer
 from jwt.exceptions import InvalidTokenError
 from pydantic import ValidationError
@@ -28,26 +29,31 @@ def get_db() -> Generator[Session]:
 SessionDep = Annotated[Session, Depends(get_db)]
 TokenDep = Annotated[str, Depends(oauth2_scheme)]
 
+# Clamped pagination query parameters for list endpoints.
+SkipParam = Annotated[int, Query(ge=0)]
+LimitParam = Annotated[int, Query(ge=1, le=100)]
+
 
 def get_current_user(session: SessionDep, token: TokenDep) -> User:
     credentials_exception = HTTPException(
-        status_code=status.HTTP_403_FORBIDDEN,
+        status_code=status.HTTP_401_UNAUTHORIZED,
         detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
     )
     try:
         payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[security.ALGORITHM])
         token_data = TokenPayload.model_validate(payload)
         if token_data.sub is None:
             raise credentials_exception
-    except (InvalidTokenError, ValidationError):
+        user_id = uuid.UUID(token_data.sub)
+    except (InvalidTokenError, ValidationError, ValueError):
         raise credentials_exception from None
 
-    user = session.get(User, token_data.sub)
+    user = session.get(User, user_id)
     if user is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="User not found",
-        )
+        # The token was valid but its user no longer exists; treat the bearer
+        # as unauthenticated rather than answering 404 on every endpoint.
+        raise credentials_exception
     if user.disabled:
         # 401 so clients treat the token as no longer valid and re-authenticate.
         raise HTTPException(

--- a/backend/src/scholark/api/routes/conferences.py
+++ b/backend/src/scholark/api/routes/conferences.py
@@ -2,10 +2,10 @@ import logging
 from datetime import UTC, datetime
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from sqlmodel import col, func, select
 
-from scholark.api.deps import CurrentUser, SessionDep, get_current_active_superuser
+from scholark.api.deps import CurrentUser, LimitParam, SessionDep, SkipParam, get_current_active_superuser
 from scholark.models import (
     Conference,
     ConferenceCreate,
@@ -18,7 +18,7 @@ from scholark.models import (
     Tag,
     TagPublic,
 )
-from scholark.slack import notify_new_conference
+from scholark.slack import build_new_conference_message, send_channel_message
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/conferences", tags=["conferences"])
@@ -45,8 +45,8 @@ def _conference_to_public(conference: Conference, user_id: UUID) -> ConferencePu
 def read_conferences(
     session: SessionDep,
     current_user: CurrentUser,
-    skip: int = 0,
-    limit: int = 100,
+    skip: SkipParam = 0,
+    limit: LimitParam = 100,
 ) -> ConferencesPublic:
     """Retrieve a list of conferences."""
     count_statement = select(func.count()).select_from(Conference)
@@ -66,6 +66,7 @@ def create_conference(
     current_user: CurrentUser,
     session: SessionDep,
     conference_in: ConferenceCreate,
+    background_tasks: BackgroundTasks,
 ) -> ConferencePublic:
     """Create a new conference."""
     milestones = conference_in.milestones or []
@@ -88,7 +89,11 @@ def create_conference(
     session.commit()
     session.refresh(conference)
 
-    notify_new_conference(conference)
+    # Build the message now (while the session is alive) but post it after
+    # the response: the Slack HTTP call must not delay conference creation.
+    notification = build_new_conference_message(conference)
+    if notification is not None:
+        background_tasks.add_task(send_channel_message, notification)
 
     return _conference_to_public(conference, current_user.id)
 

--- a/backend/src/scholark/api/routes/tags.py
+++ b/backend/src/scholark/api/routes/tags.py
@@ -3,7 +3,7 @@ import uuid
 from fastapi import APIRouter, HTTPException
 from sqlmodel import col, func, select
 
-from scholark.api.deps import CurrentUser, SessionDep
+from scholark.api.deps import CurrentUser, LimitParam, SessionDep, SkipParam
 from scholark.models import Tag, TagCreate, TagPublic, TagsPublic, TagUpdate
 
 router = APIRouter(prefix="/tags", tags=["tags"])
@@ -14,8 +14,8 @@ def read_tags(
     session: SessionDep,
     current_user: CurrentUser,
     *,
-    skip: int = 0,
-    limit: int = 100,
+    skip: SkipParam = 0,
+    limit: LimitParam = 100,
     all_users: bool = False,
 ) -> TagsPublic:
     """Retrieve a list of tags."""
@@ -96,13 +96,13 @@ def update_tag(
     return tag
 
 
-@router.delete("/{tag_id}", response_model=TagPublic)
+@router.delete("/{tag_id}")
 def delete_tag(
     *,
     current_user: CurrentUser,
     session: SessionDep,
     tag_id: uuid.UUID,
-) -> Tag:
+) -> TagPublic:
     """Delete a tag."""
     tag = session.get(Tag, tag_id)
     if not tag:
@@ -110,6 +110,8 @@ def delete_tag(
     if not current_user.is_superuser and tag.user_id != current_user.id:
         raise HTTPException(status_code=403, detail="Not authorized to delete this tag")
 
+    # Serialize before deleting; the ORM instance is unusable after the flush.
+    tag_public = TagPublic.model_validate(tag)
     session.delete(tag)
     session.commit()
-    return tag
+    return tag_public

--- a/backend/src/scholark/api/routes/users.py
+++ b/backend/src/scholark/api/routes/users.py
@@ -4,7 +4,14 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException
 from sqlmodel import func, select
 
-from scholark.api.deps import AuthProviderDep, CurrentUser, SessionDep, get_current_active_superuser
+from scholark.api.deps import (
+    AuthProviderDep,
+    CurrentUser,
+    LimitParam,
+    SessionDep,
+    SkipParam,
+    get_current_active_superuser,
+)
 from scholark.models import (
     Message,
     User,
@@ -23,7 +30,7 @@ router = APIRouter(prefix="/users", tags=["users"])
     dependencies=[Depends(get_current_active_superuser)],
     response_model=UsersPublic,
 )
-def read_users(session: SessionDep, skip: int = 0, limit: int = 100) -> Any:
+def read_users(session: SessionDep, skip: SkipParam = 0, limit: LimitParam = 100) -> Any:
     """Retrieve users."""
     count_statement = select(func.count()).select_from(User)
     count = session.exec(count_statement).one()
@@ -47,7 +54,7 @@ def create_user(*, user_in: UserCreate, auth_provider: AuthProviderDep) -> Any:
     if user is not None:
         raise HTTPException(
             status_code=400,
-            detail="The user with this email already exists in the system.",
+            detail="A user with this username already exists in the system.",
         )
 
     return auth_provider.create_user(user_create=user_in)
@@ -82,7 +89,7 @@ def register_user(auth_provider: AuthProviderDep, user_in: UserRegister) -> Any:
     if user is not None:
         raise HTTPException(
             status_code=400,
-            detail="The user with this email already exists in the system",
+            detail="A user with this username already exists in the system",
         )
     user_create = UserCreate.model_validate(user_in)
     return auth_provider.create_user(user_create=user_create)

--- a/backend/src/scholark/auth/db_provider.py
+++ b/backend/src/scholark/auth/db_provider.py
@@ -1,3 +1,5 @@
+from functools import lru_cache
+
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session, select
 
@@ -5,6 +7,16 @@ from scholark.core.security import get_password_hash, verify_password
 from scholark.models import DbAuthCredential, User, UserCreate, default_tags
 
 from .base import AuthProvider, AuthProviderError
+
+
+@lru_cache(maxsize=1)
+def _dummy_password_hash() -> str:
+    """Hash to verify against when a username has no credential.
+
+    Verifying a dummy hash keeps the response time of unknown-username logins
+    close to that of known usernames, preventing username enumeration.
+    """
+    return get_password_hash("scholark-dummy-password")
 
 
 class DbAuthProvider(AuthProvider):
@@ -55,13 +67,16 @@ class DbAuthProvider(AuthProvider):
 
     def authenticate(self, username: str, password: str) -> User | None:
         db_user = self.db.exec(select(User).where(User.username == username)).one_or_none()
-        if not db_user:
-            return None
+        db_cred = None
+        if db_user:
+            db_cred = self.db.exec(
+                select(DbAuthCredential).where(DbAuthCredential.user_id == db_user.id),
+            ).one_or_none()
 
-        db_cred = self.db.exec(
-            select(DbAuthCredential).where(DbAuthCredential.user_id == db_user.id),
-        ).one_or_none()
-        if db_cred is None or not verify_password(password, db_cred.hashed_password):
+        if db_cred is None:
+            verify_password(password, _dummy_password_hash())
+            return None
+        if not verify_password(password, db_cred.hashed_password):
             return None
 
         return db_user

--- a/backend/src/scholark/core/config.py
+++ b/backend/src/scholark/core/config.py
@@ -63,6 +63,8 @@ class Settings(BaseSettings):
     # Slack integration (optional)
     SLACK_BOT_TOKEN: str | None = None
     SLACK_CHANNEL_ID: str | None = None
+    # IANA timezone used to compute "today" for milestone reminders.
+    REMINDER_TIMEZONE: str = "UTC"
 
 
 # Missing argument is intentional to allow environment variables to populate the settings.

--- a/backend/src/scholark/main.py
+++ b/backend/src/scholark/main.py
@@ -34,10 +34,11 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:  # noqa: ARG001
             init_db(session)
             logger.info("Database initialization completed successfully.")
         except Exception:
-            logger.exception("Database initialization failed")
-            logger.exception("This might happen if migrations haven't been run yet.")
-            logger.exception("In production, ensure migrations are run before starting the application.")
-            logger.exception("For development, auto-migration can be enabled with SCHOLARK_DB_AUTO_MIGRATE=true")
+            logger.exception(
+                "Database initialization failed. This can happen when migrations haven't been applied; "
+                "run them before starting the application (the container startup script does this "
+                "automatically when SCHOLARK_DB_AUTO_MIGRATE=true).",
+            )
             raise
     yield
 

--- a/backend/src/scholark/models.py
+++ b/backend/src/scholark/models.py
@@ -2,10 +2,17 @@ import uuid
 from datetime import UTC, datetime
 from datetime import date as date_
 from datetime import time as time_
+from typing import Annotated
 
 import sqlalchemy as sa
-from pydantic import computed_field
+from pydantic import StringConstraints, computed_field
 from sqlmodel import Field, Relationship, SQLModel
+
+# Validation applies to the create/update payload models only: table models
+# skip validation, and constraining the public (response) models would turn
+# pre-existing non-conforming rows into 500s on read.
+HexColor = Annotated[str, StringConstraints(pattern=r"^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$")]
+NonEmptyStr = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
 
 
 class TagConferenceLink(SQLModel, table=True):
@@ -25,12 +32,13 @@ class TagBase(SQLModel):
 
 
 class TagCreate(TagBase):
-    pass
+    name: NonEmptyStr
+    color: HexColor
 
 
 class TagUpdate(SQLModel):
-    name: str | None = Field(default=None)
-    color: str | None = Field(default=None)
+    name: NonEmptyStr | None = Field(default=None)
+    color: HexColor | None = Field(default=None)
 
 
 class Tag(TagBase, table=True):
@@ -114,10 +122,12 @@ class ConferenceBase(SQLModel):
 
 
 class ConferenceCreate(ConferenceBase):
+    name: NonEmptyStr
     milestones: list[ConferenceMilestoneCreate] | None = Field(default=None)
 
 
 class ConferenceUpdate(ConferenceBase):
+    name: NonEmptyStr
     milestones: list[ConferenceMilestoneUpdate] | None = Field(default=None)
 
 
@@ -138,7 +148,7 @@ class ConferencePublic(ConferenceBase):
     updated_at: datetime
     created_by_user_id: uuid.UUID | None
 
-    tags: list[TagPublic] = Field(default=None)
+    tags: list[TagPublic] = Field(default_factory=list)
     milestones: list[ConferenceMilestonePublic]
     is_subscribed: bool = Field(default=False)
 

--- a/backend/src/scholark/slack.py
+++ b/backend/src/scholark/slack.py
@@ -1,5 +1,6 @@
 import logging
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
 
 from slack_sdk import WebClient
 from sqlmodel import Session, col, select
@@ -17,46 +18,57 @@ def _get_slack_client() -> WebClient | None:
     return WebClient(token=settings.SLACK_BOT_TOKEN)
 
 
-def notify_new_conference(conference: Conference) -> None:
-    """Post a notification about a new conference to the configured Slack channel.
+def build_new_conference_message(conference: Conference) -> str | None:
+    """Build the Slack notification text for a new conference.
 
-    No-op if Slack is not configured. Errors are logged but never raised.
+    Pure message construction; returns None if Slack is not configured.
+    """
+    if not settings.SLACK_BOT_TOKEN or not settings.SLACK_CHANNEL_ID:
+        return None
+
+    scholark_url = settings.FRONTEND_HOST.rstrip("/")
+    lines = [
+        f":mega: New conference added: *{conference.name}*",
+    ]
+
+    meta_parts: list[str] = []
+    if conference.start_date and conference.end_date:
+        meta_parts.append(f":date: {conference.start_date} \u2013 {conference.end_date}")
+    elif conference.start_date:
+        meta_parts.append(f":date: {conference.start_date}")
+    if conference.location:
+        meta_parts.append(f":round_pushpin: {conference.location}")
+    if meta_parts:
+        lines.append(" | ".join(meta_parts))
+
+    link_parts: list[str] = []
+    if conference.website_url:
+        link_parts.append(f"<{conference.website_url}|Website>")
+    link_parts.append(f"<{scholark_url}/conferences|View in Scholark>")
+    lines.append(" \u00b7 ".join(link_parts))
+
+    if conference.milestones:
+        milestone_strs = [f"{m.name} ({m.date})" for m in sorted(conference.milestones, key=lambda m: m.date)]
+        lines.append(f"Milestones: {', '.join(milestone_strs)}")
+
+    return "\n".join(lines)
+
+
+def send_channel_message(text: str) -> None:
+    """Post a message to the configured Slack channel.
+
+    No-op if Slack is not configured. Errors are logged but never raised, so
+    this is safe to run as a background task.
     """
     client = _get_slack_client()
     if client is None or not settings.SLACK_CHANNEL_ID:
         return
 
     try:
-        scholark_url = settings.FRONTEND_HOST.rstrip("/")
-        lines = [
-            f":mega: New conference added: *{conference.name}*",
-        ]
-
-        meta_parts: list[str] = []
-        if conference.start_date and conference.end_date:
-            meta_parts.append(f":date: {conference.start_date} \u2013 {conference.end_date}")
-        elif conference.start_date:
-            meta_parts.append(f":date: {conference.start_date}")
-        if conference.location:
-            meta_parts.append(f":round_pushpin: {conference.location}")
-        if meta_parts:
-            lines.append(" | ".join(meta_parts))
-
-        link_parts: list[str] = []
-        if conference.website_url:
-            link_parts.append(f"<{conference.website_url}|Website>")
-        link_parts.append(f"<{scholark_url}/conferences|View in Scholark>")
-        lines.append(" \u00b7 ".join(link_parts))
-
-        if conference.milestones:
-            milestone_strs = [f"{m.name} ({m.date})" for m in sorted(conference.milestones, key=lambda m: m.date)]
-            lines.append(f"Milestones: {', '.join(milestone_strs)}")
-
-        text = "\n".join(lines)
         client.chat_postMessage(channel=settings.SLACK_CHANNEL_ID, text=text)
-        logger.info(f"Slack notification sent for conference {conference.name}")
+        logger.info("Slack channel notification sent")
     except Exception:
-        logger.exception(f"Failed to send Slack notification for conference {conference.name}")
+        logger.exception("Failed to send Slack channel notification")
 
 
 def send_milestone_reminders(session: Session) -> None:
@@ -70,7 +82,9 @@ def send_milestone_reminders(session: Session) -> None:
         logger.info("Slack not configured, skipping milestone reminders")
         return
 
-    today = datetime.now(tz=UTC).date()
+    # "Today" in the configured reminder timezone; computing it in UTC would
+    # deliver the 7/30-day reminders a day early for users west of UTC.
+    today = datetime.now(tz=ZoneInfo(settings.REMINDER_TIMEZONE)).date()
     target_dates = {
         today + timedelta(days=30): 30,
         today + timedelta(days=7): 7,


### PR DESCRIPTION
- lifespan: one logger.exception with accurate advice instead of four
  tracebacks; the app itself never reads SCHOLARK_DB_AUTO_MIGRATE.
- 'user with this email' -> 'username' in user-exists errors.
- get_current_user: 401 (with WWW-Authenticate) for invalid tokens and
  for tokens whose user was deleted, instead of 403/404.
- Clamp skip/limit query params (ge=0 / 1..100) on all list endpoints.
- Send the new-conference Slack notification from a background task;
  build_new_conference_message is pure, send_channel_message does IO.
- Verify a dummy hash for unknown usernames so login response time
  does not reveal whether a username exists.
- Compute reminder 'today' in a configurable SCHOLARK_REMINDER_TIMEZONE
  instead of UTC.
- Validate tag colors (#rgb/#rrggbb) and non-empty tag/conference names
  on create/update payloads.
- ConferencePublic.tags: default_factory=list instead of a None default
  on a non-optional list.
- startup.sh: drop the dead $? check under set -e.
- delete_tag: serialize the response before deleting the row.
(Review item 2.6; also the backend halves of 3.2/3.7 validation)

<!-- GitButler Footer Boundary Top -->
---
This is **part 5 of 7 in a stack** made with GitButler:
- <kbd>&nbsp;7&nbsp;</kbd> #781 
- <kbd>&nbsp;6&nbsp;</kbd> #780 
- <kbd>&nbsp;5&nbsp;</kbd> #779 👈 
- <kbd>&nbsp;4&nbsp;</kbd> #778 
- <kbd>&nbsp;3&nbsp;</kbd> #777 
- <kbd>&nbsp;2&nbsp;</kbd> #796 
- <kbd>&nbsp;1&nbsp;</kbd> #795 
<!-- GitButler Footer Boundary Bottom -->

