### PR TITLE
Clean up auth abstraction and ORM comparisons

### DIFF
--- a/backend/src/scholark/api/routes/users.py
+++ b/backend/src/scholark/api/routes/users.py
@@ -103,7 +103,7 @@ def read_user_by_id(
 ) -> Any:
     """Get a specific user by id."""
     user = session.get(User, user_id)
-    if user == current_user:
+    if user is not None and user.id == current_user.id:
         return user
     if not current_user.is_superuser:
         raise HTTPException(
@@ -125,13 +125,11 @@ def delete_user(
     user = session.get(User, user_id)
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
-    if user == current_user:
+    if user.id == current_user.id:
         raise HTTPException(
             status_code=403,
             detail="Super users are not allowed to delete themselves",
         )
-    # statement = delete(Item).where(col(Item.owner_id) == user_id)
-    # session.exec(statement)
     session.delete(user)
     session.commit()
     return Message(message="User deleted successfully")

--- a/backend/src/scholark/auth/base.py
+++ b/backend/src/scholark/auth/base.py
@@ -1,29 +1,30 @@
 from abc import ABC, abstractmethod
 
-from fastapi import HTTPException
-
 from scholark.models import User, UserCreate
 
 
-class AuthProviderError(HTTPException):
-    pass
+class AuthProviderError(Exception):
+    """Error raised by authentication providers.
+
+    Deliberately not an HTTPException so the auth layer stays independent of
+    the web framework; the FastAPI app maps it to a JSON error response.
+    """
+
+    def __init__(self, status_code: int, detail: str) -> None:
+        super().__init__(detail)
+        self.status_code = status_code
+        self.detail = detail
 
 
 class AuthProvider(ABC):
     @abstractmethod
     def authenticate(self, username: str, password: str) -> User | None:
         """Authenticate a user with username and password."""
-        msg = "Subclasses must implement this method."
-        raise NotImplementedError(msg)
 
     @abstractmethod
     def get_user_by_username(self, *, username: str) -> User | None:
         """Get a user by username."""
-        msg = "Subclasses must implement this method."
-        raise NotImplementedError(msg)
 
     @abstractmethod
     def create_user(self, *, user_create: UserCreate) -> User:
         """Create a new user."""
-        msg = "Subclasses must implement this method."
-        raise NotImplementedError(msg)

--- a/backend/src/scholark/main.py
+++ b/backend/src/scholark/main.py
@@ -2,12 +2,14 @@ import logging
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 from fastapi.routing import APIRoute
 from sqlmodel import Session, select
 
 from scholark.api.main import api_router
+from scholark.auth.base import AuthProviderError
 from scholark.core.config import settings
 from scholark.core.db import engine, init_db
 
@@ -58,6 +60,12 @@ if settings.all_cors_origins:
         allow_methods=["*"],
         allow_headers=["*"],
     )
+
+
+@app.exception_handler(AuthProviderError)
+def auth_provider_error_handler(request: Request, exc: AuthProviderError) -> JSONResponse:  # noqa: ARG001
+    return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
+
 
 app.include_router(api_router, prefix=settings.API_V1_STR)
 


### PR DESCRIPTION
- AuthProvider abstract methods no longer both use `@abstractmethod` and
  raise NotImplementedError with an unused message.
- AuthProviderError is a plain exception (status_code + detail) instead
  of subclassing FastAPI's HTTPException; a small app-level exception
  handler maps it to a JSON response, decoupling the auth layer from
  the web framework.
- users.py: compare user ids instead of ORM instances, and drop
  commented-out dead code left from the template.
(Review section 4 smells)

<!-- GitButler Footer Boundary Top -->
---
This is **part 6 of 7 in a stack** made with GitButler:
- <kbd>&nbsp;7&nbsp;</kbd> #781 
- <kbd>&nbsp;6&nbsp;</kbd> #780 👈 
- <kbd>&nbsp;5&nbsp;</kbd> #779 
- <kbd>&nbsp;4&nbsp;</kbd> #778 
- <kbd>&nbsp;3&nbsp;</kbd> #777 
- <kbd>&nbsp;2&nbsp;</kbd> #796 
- <kbd>&nbsp;1&nbsp;</kbd> #795 
<!-- GitButler Footer Boundary Bottom -->

