### PR TITLE
Extract a requireSession helper for loaders and actions

### DIFF
--- a/frontend/app/lib/auth.server.ts
+++ b/frontend/app/lib/auth.server.ts
@@ -1,0 +1,23 @@
+import { redirect } from "react-router";
+import { getSession } from "~/sessions.server";
+
+type Session = Awaited<ReturnType<typeof getSession>>;
+
+export interface AuthenticatedSession {
+  session: Session;
+  token: string;
+  authHeaders: { Authorization: string };
+}
+
+/**
+ * Load the session for a request and require a logged-in user.
+ * Throws a redirect to /login when no access token is present.
+ */
+export async function requireSession(request: Request): Promise<AuthenticatedSession> {
+  const session = await getSession(request.headers.get("Cookie"));
+  const token = session.get("accessToken");
+  if (!token) {
+    throw redirect("/login");
+  }
+  return { session, token, authHeaders: { Authorization: `Bearer ${token}` } };
+}

--- a/frontend/app/routes/conference-subscribe.tsx
+++ b/frontend/app/routes/conference-subscribe.tsx
@@ -1,20 +1,14 @@
 import { data, redirect } from "react-router";
 import { conferencesSubscribeToConference, conferencesUnsubscribeFromConference } from "~/client";
-import { getSession } from "~/sessions.server";
+import { requireSession } from "~/lib/auth.server";
 import type { Route } from "./+types/conference-subscribe";
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const session = await getSession(request.headers.get("Cookie"));
-  if (!session.has("accessToken")) {
-    return redirect("/login");
-  }
+  const { authHeaders: headers } = await requireSession(request);
 
   if (!params.conferenceId) {
     throw data("Conference ID is required", { status: 400 });
   }
-
-  const token = session.get("accessToken");
-  const headers = { Authorization: `Bearer ${token}` };
 
   if (request.method === "DELETE") {
     const { error } = await conferencesUnsubscribeFromConference({

--- a/frontend/app/routes/conference-tags.tsx
+++ b/frontend/app/routes/conference-tags.tsx
@@ -1,14 +1,11 @@
 import { data, redirect } from "react-router";
 import { conferencesUpdateTagsForConference } from "~/client";
 import type { Option } from "~/components/ui/multi-select";
-import { getSession } from "~/sessions.server";
+import { requireSession } from "~/lib/auth.server";
 import type { Route } from "./+types/conference-tags";
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const session = await getSession(request.headers.get("Cookie"));
-  if (!session.has("accessToken")) {
-    return redirect("/login");
-  }
+  const { authHeaders } = await requireSession(request);
 
   const formData = await request.formData();
   const tags = JSON.parse(formData.get("tags") as string) as Option[];
@@ -18,7 +15,7 @@ export async function action({ request, params }: Route.ActionArgs) {
   }
   const { error } = await conferencesUpdateTagsForConference({
     path: { conference_id: params.conferenceId },
-    headers: { Authorization: `Bearer ${session.get("accessToken")}` },
+    headers: authHeaders,
     body: tags.map((tag) => tag.value),
   });
   if (error) {

--- a/frontend/app/routes/conferences.tsx
+++ b/frontend/app/routes/conferences.tsx
@@ -1,5 +1,5 @@
 import { Bell, BellOff, Calendar, MapPin, Pencil, Plus, Trash2 } from "lucide-react";
-import { data, Form, redirect, useSearchParams, useSubmit } from "react-router";
+import { data, Form, useSearchParams, useSubmit } from "react-router";
 import type { ConferencePublic } from "~/client";
 import { conferencesReadConferences, tagsReadTags } from "~/client";
 import {
@@ -25,27 +25,23 @@ import {
 } from "~/components/ui/card";
 import MultipleSelector from "~/components/ui/multi-select";
 import { Switch } from "~/components/ui/switch";
+import { requireSession } from "~/lib/auth.server";
 import { pickLabelTextColor } from "~/lib/color";
-import { getSession } from "~/sessions.server";
 import type { Route } from "./+types/conferences";
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const session = await getSession(request.headers.get("Cookie"));
-  if (!session.has("accessToken")) {
-    return redirect("/login");
-  }
-  const token = session.get("accessToken");
+  const { session, authHeaders } = await requireSession(request);
   const isSuperUser = session.get("isSuperUser") ?? false;
 
   const { data: conferences, error } = await conferencesReadConferences({
-    headers: { Authorization: `Bearer ${token}` },
+    headers: authHeaders,
   });
   if (error) {
     throw data("Error fetching conferences", { status: 500 });
   }
 
   const { data: tags, error: tagsError } = await tagsReadTags({
-    headers: { Authorization: `Bearer ${token}` },
+    headers: authHeaders,
   });
   if (tagsError) {
     throw data("Error fetching tags", { status: 500 });

--- a/frontend/app/routes/create-conference.tsx
+++ b/frontend/app/routes/create-conference.tsx
@@ -6,14 +6,11 @@ import { conferencesCreateConference } from "~/client";
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
-import { getSession } from "~/sessions.server";
+import { requireSession } from "~/lib/auth.server";
 import type { Route } from "./+types/create-conference";
 
 export async function action({ request }: Route.ActionArgs) {
-  const session = await getSession(request.headers.get("Cookie"));
-  if (!session.has("accessToken")) {
-    return redirect("/login");
-  }
+  const { authHeaders } = await requireSession(request);
 
   const formData = await request.formData();
   const updates = Object.fromEntries(formData) as Record<string, string | null>;
@@ -52,7 +49,7 @@ export async function action({ request }: Route.ActionArgs) {
 
   await conferencesCreateConference({
     body: requestBody,
-    headers: { Authorization: `Bearer ${session.get("accessToken")}` },
+    headers: authHeaders,
   });
   return redirect(`/conferences`);
 }

--- a/frontend/app/routes/create-tag.tsx
+++ b/frontend/app/routes/create-tag.tsx
@@ -1,7 +1,7 @@
 import { data, redirect } from "react-router";
 import type { TagCreate } from "~/client";
 import { tagsCreateTag } from "~/client";
-import { getSession } from "~/sessions.server";
+import { requireSession } from "~/lib/auth.server";
 import type { Route } from "./+types/create-tag";
 
 // export async function loader({ request, params }: Route.LoaderArgs) {
@@ -20,10 +20,7 @@ import type { Route } from "./+types/create-tag";
 // }
 
 export async function action({ request }: Route.ActionArgs) {
-  const session = await getSession(request.headers.get("Cookie"));
-  if (!session.has("accessToken")) {
-    return redirect("/login");
-  }
+  const { authHeaders } = await requireSession(request);
 
   const formData = await request.formData();
   const tagName = formData.get("name") as string;
@@ -35,7 +32,7 @@ export async function action({ request }: Route.ActionArgs) {
   };
 
   const { error } = await tagsCreateTag({
-    headers: { Authorization: `Bearer ${session.get("accessToken")}` },
+    headers: authHeaders,
     body: tagCreate,
   });
   if (error) {

--- a/frontend/app/routes/delete-conference.tsx
+++ b/frontend/app/routes/delete-conference.tsx
@@ -1,20 +1,17 @@
 import { data, redirect } from "react-router";
 import { conferencesDeleteConference } from "~/client";
-import { getSession } from "~/sessions.server";
+import { requireSession } from "~/lib/auth.server";
 import type { Route } from "./+types/delete-conference";
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const session = await getSession(request.headers.get("Cookie"));
-  if (!session.has("accessToken")) {
-    return redirect("/login");
-  }
+  const { authHeaders } = await requireSession(request);
 
   if (!params.conferenceId) {
     throw data("Conference ID is required", { status: 400 });
   }
   await conferencesDeleteConference({
     path: { conference_id: params.conferenceId },
-    headers: { Authorization: `Bearer ${session.get("accessToken")}` },
+    headers: authHeaders,
   });
   return redirect("/conferences");
 }

--- a/frontend/app/routes/delete-tag.tsx
+++ b/frontend/app/routes/delete-tag.tsx
@@ -1,6 +1,6 @@
 import { data, redirect } from "react-router";
 import { tagsDeleteTag } from "~/client";
-import { getSession } from "~/sessions.server";
+import { requireSession } from "~/lib/auth.server";
 import type { Route } from "./+types/delete-tag";
 
 // export async function loader({ request, params }: Route.LoaderArgs) {
@@ -19,14 +19,11 @@ import type { Route } from "./+types/delete-tag";
 // }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const session = await getSession(request.headers.get("Cookie"));
-  if (!session.has("accessToken")) {
-    return redirect("/login");
-  }
+  const { authHeaders } = await requireSession(request);
 
   const { error } = await tagsDeleteTag({
     path: { tag_id: params.tagId },
-    headers: { Authorization: `Bearer ${session.get("accessToken")}` },
+    headers: authHeaders,
   });
   if (error) {
     throw data("Tag not found", { status: 404 });

--- a/frontend/app/routes/edit-conference.tsx
+++ b/frontend/app/routes/edit-conference.tsx
@@ -6,17 +6,14 @@ import { conferencesReadConference, conferencesUpdateConference } from "~/client
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
-import { getSession } from "~/sessions.server";
+import { requireSession } from "~/lib/auth.server";
 import type { Route } from "./+types/edit-conference";
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const session = await getSession(request.headers.get("Cookie"));
-  if (!session.has("accessToken")) {
-    return redirect("/login");
-  }
+  const { authHeaders } = await requireSession(request);
   const { data: conference, error } = await conferencesReadConference({
     path: { conference_id: params.conferenceId },
-    headers: { Authorization: `Bearer ${session.get("accessToken")}` },
+    headers: authHeaders,
   });
   if (error) {
     throw data("Conference not found", { status: 404 });
@@ -25,10 +22,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const session = await getSession(request.headers.get("Cookie"));
-  if (!session.has("accessToken")) {
-    return redirect("/login");
-  }
+  const { authHeaders } = await requireSession(request);
   const formData = await request.formData();
   const updates = Object.fromEntries(formData) as Record<string, string | null>;
   // For fields other than name, set to null if empty
@@ -66,7 +60,7 @@ export async function action({ request, params }: Route.ActionArgs) {
   await conferencesUpdateConference({
     path: { conference_id: params.conferenceId },
     body: requestBody,
-    headers: { Authorization: `Bearer ${session.get("accessToken")}` },
+    headers: authHeaders,
   });
   return redirect(`/conferences`);
 }

--- a/frontend/app/routes/edit-tag.tsx
+++ b/frontend/app/routes/edit-tag.tsx
@@ -1,17 +1,14 @@
 import { data, redirect } from "react-router";
 import type { TagUpdate } from "~/client";
 import { tagsReadTag, tagsUpdateTag } from "~/client";
-import { getSession } from "~/sessions.server";
+import { requireSession } from "~/lib/auth.server";
 import type { Route } from "./+types/edit-tag";
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const session = await getSession(request.headers.get("Cookie"));
-  if (!session.has("accessToken")) {
-    return redirect("/login");
-  }
+  const { authHeaders } = await requireSession(request);
   const { data: tag, error } = await tagsReadTag({
     path: { tag_id: params.tagId },
-    headers: { Authorization: `Bearer ${session.get("accessToken")}` },
+    headers: authHeaders,
   });
   if (error) {
     throw data("Conference not found", { status: 404 });
@@ -20,10 +17,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const session = await getSession(request.headers.get("Cookie"));
-  if (!session.has("accessToken")) {
-    return redirect("/login");
-  }
+  const { authHeaders } = await requireSession(request);
   const formData = await request.formData();
   const tagName = formData.get("name") as string | null;
   const tagColor = formData.get("color") as string | null;
@@ -35,7 +29,7 @@ export async function action({ request, params }: Route.ActionArgs) {
 
   const { error } = await tagsUpdateTag({
     path: { tag_id: params.tagId },
-    headers: { Authorization: `Bearer ${session.get("accessToken")}` },
+    headers: authHeaders,
     body: tagUpdate,
   });
   if (error) {

--- a/frontend/app/routes/settings.tsx
+++ b/frontend/app/routes/settings.tsx
@@ -25,8 +25,8 @@ import {
 } from "~/components/ui/dialog";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
+import { requireSession } from "~/lib/auth.server";
 import { pickLabelTextColor } from "~/lib/color";
-import { getSession } from "~/sessions.server";
 import type { Route } from "./+types/settings";
 // User settings
 // - Add/edit/delete user tags
@@ -35,15 +35,12 @@ import type { Route } from "./+types/settings";
 // - Change username
 
 export async function action({ request }: Route.ActionArgs) {
-  const session = await getSession(request.headers.get("Cookie"));
-  if (!session.has("accessToken")) {
-    return redirect("/login");
-  }
+  const { authHeaders } = await requireSession(request);
   const formData = await request.formData();
   const slackUserId = formData.get("slack_user_id") as string | null;
 
   const { error } = await usersUpdateUserMe({
-    headers: { Authorization: `Bearer ${session.get("accessToken")}` },
+    headers: authHeaders,
     body: { slack_user_id: slackUserId || null },
   });
   if (error) {
@@ -53,20 +50,17 @@ export async function action({ request }: Route.ActionArgs) {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const session = await getSession(request.headers.get("Cookie"));
-  if (!session.has("accessToken")) {
-    return redirect("/login");
-  }
+  const { authHeaders } = await requireSession(request);
 
   const { data: user, error: userError } = await usersReadUserMe({
-    headers: { Authorization: `Bearer ${session.get("accessToken")}` },
+    headers: authHeaders,
   });
   if (userError || !user) {
     throw data("User not found", { status: 404 });
   }
 
   const { data: userTags, error: userTagsError } = await tagsReadTags({
-    headers: { Authorization: `Bearer ${session.get("accessToken")}` },
+    headers: authHeaders,
   });
   if (userTagsError || !userTags) {
     throw data("User tags not found", { status: 404 });

--- a/frontend/app/routes/timeline.tsx
+++ b/frontend/app/routes/timeline.tsx
@@ -1,5 +1,5 @@
 import { Calendar } from "lucide-react";
-import { data, redirect, useSearchParams } from "react-router";
+import { data, useSearchParams } from "react-router";
 import { conferencesReadConferences, tagsReadTags } from "~/client";
 import { Badge } from "~/components/ui/badge";
 import { Card, CardDescription, CardFooter, CardHeader, CardTitle } from "~/components/ui/card";
@@ -14,8 +14,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "~/components/ui/select";
+import { requireSession } from "~/lib/auth.server";
 import { pickLabelTextColor } from "~/lib/color";
-import { getSession } from "~/sessions.server";
 import type { Route } from "./+types/timeline";
 
 // Define the schedule item interface
@@ -31,39 +31,23 @@ interface ScheduleItem {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const session = await getSession(request.headers.get("Cookie"));
-  if (!session.has("accessToken")) {
-    return redirect("/login");
-  }
-  const token = session.get("accessToken");
+  const { authHeaders } = await requireSession(request);
 
   const { data: conferences, error } = await conferencesReadConferences({
-    headers: { Authorization: `Bearer ${token}` },
+    headers: authHeaders,
   });
   if (error) {
     throw new Response("Error fetching conferences", { status: 500 });
   }
 
   const { data: userTags, error: userTagsError } = await tagsReadTags({
-    headers: { Authorization: `Bearer ${session.get("accessToken")}` },
+    headers: authHeaders,
   });
   if (userTagsError || !userTags) {
     throw data("User tags not found", { status: 404 });
   }
 
-  // const formData = await request.formData();
-  // const selectedTagId = formData.get("selectedTagId") as string | null;
   return { conferences, userTags };
-}
-
-export async function action({ request }: Route.ActionArgs) {
-  const session = await getSession(request.headers.get("Cookie"));
-  if (!session.has("accessToken")) {
-    return redirect("/login");
-  }
-
-  const formData = await request.formData();
-  const _selectedTagId = formData.get("selectedTagId") as string | null;
 }
 
 export default function Timeline({ loaderData }: Route.ComponentProps) {


### PR DESCRIPTION
Every protected loader/action repeated the getSession ->
has('accessToken') -> redirect('/login') dance and built the
Authorization header by hand (~15 copies). requireSession(request)
returns the session, token, and ready-made auth headers, or throws a
redirect to /login. Also drops timeline's dead action, whose only
content was that boilerplate. (Review section 4; 3.7 dead action)

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 11 in a stack** made with GitButler:
- <kbd>&nbsp;11&nbsp;</kbd> #792 
- <kbd>&nbsp;10&nbsp;</kbd> #791 
- <kbd>&nbsp;9&nbsp;</kbd> #790 
- <kbd>&nbsp;8&nbsp;</kbd> #789 
- <kbd>&nbsp;7&nbsp;</kbd> #788 
- <kbd>&nbsp;6&nbsp;</kbd> #787 
- <kbd>&nbsp;5&nbsp;</kbd> #786 
- <kbd>&nbsp;4&nbsp;</kbd> #785 
- <kbd>&nbsp;3&nbsp;</kbd> #784 
- <kbd>&nbsp;2&nbsp;</kbd> #783 
- <kbd>&nbsp;1&nbsp;</kbd> #782 👈 
<!-- GitButler Footer Boundary Bottom -->

