### PR TITLE
Send users back to the login page when their token expires

### DIFF
--- a/frontend/app/lib/auth.server.ts
+++ b/frontend/app/lib/auth.server.ts
@@ -1,5 +1,5 @@
 import { redirect } from "react-router";
-import { getSession } from "~/sessions.server";
+import { destroySession, getSession } from "~/sessions.server";
 
 type Session = Awaited<ReturnType<typeof getSession>>;
 
@@ -20,4 +20,23 @@ export async function requireSession(request: Request): Promise<AuthenticatedSes
     throw redirect("/login");
   }
   return { session, token, authHeaders: { Authorization: `Bearer ${token}` } };
+}
+
+/**
+ * If the API rejected the request's credentials (expired token, or a disabled
+ * or deleted user), destroy the session and redirect to the login page.
+ *
+ * The session cookie outlives the JWT, so without this every loader threw a
+ * generic 500 and stranded returning users on an error page. Call after an
+ * API error before converting it into an error response.
+ */
+export async function logoutIfUnauthorized(
+  session: Session,
+  response: Response | undefined,
+): Promise<void> {
+  if (response?.status === 401) {
+    throw redirect("/login", {
+      headers: { "Set-Cookie": await destroySession(session) },
+    });
+  }
 }

--- a/frontend/app/routes/conference-subscribe.tsx
+++ b/frontend/app/routes/conference-subscribe.tsx
@@ -1,29 +1,31 @@
 import { data, redirect } from "react-router";
 import { conferencesSubscribeToConference, conferencesUnsubscribeFromConference } from "~/client";
-import { requireSession } from "~/lib/auth.server";
+import { logoutIfUnauthorized, requireSession } from "~/lib/auth.server";
 import type { Route } from "./+types/conference-subscribe";
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { authHeaders: headers } = await requireSession(request);
+  const { session, authHeaders: headers } = await requireSession(request);
 
   if (!params.conferenceId) {
     throw data("Conference ID is required", { status: 400 });
   }
 
   if (request.method === "DELETE") {
-    const { error } = await conferencesUnsubscribeFromConference({
+    const { error, response } = await conferencesUnsubscribeFromConference({
       path: { conference_id: params.conferenceId },
       headers,
     });
     if (error) {
+      await logoutIfUnauthorized(session, response);
       throw data("Failed to unsubscribe", { status: 500 });
     }
   } else {
-    const { error } = await conferencesSubscribeToConference({
+    const { error, response } = await conferencesSubscribeToConference({
       path: { conference_id: params.conferenceId },
       headers,
     });
     if (error) {
+      await logoutIfUnauthorized(session, response);
       throw data("Failed to subscribe", { status: 500 });
     }
   }

--- a/frontend/app/routes/conference-tags.tsx
+++ b/frontend/app/routes/conference-tags.tsx
@@ -1,11 +1,11 @@
 import { data, redirect } from "react-router";
 import { conferencesUpdateTagsForConference } from "~/client";
 import type { Option } from "~/components/ui/multi-select";
-import { requireSession } from "~/lib/auth.server";
+import { logoutIfUnauthorized, requireSession } from "~/lib/auth.server";
 import type { Route } from "./+types/conference-tags";
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { authHeaders } = await requireSession(request);
+  const { session, authHeaders } = await requireSession(request);
 
   const formData = await request.formData();
   const tags = JSON.parse(formData.get("tags") as string) as Option[];
@@ -13,12 +13,13 @@ export async function action({ request, params }: Route.ActionArgs) {
   if (!params.conferenceId) {
     throw data("Conference ID is required", { status: 400 });
   }
-  const { error } = await conferencesUpdateTagsForConference({
+  const { error, response } = await conferencesUpdateTagsForConference({
     path: { conference_id: params.conferenceId },
     headers: authHeaders,
     body: tags.map((tag) => tag.value),
   });
   if (error) {
+    await logoutIfUnauthorized(session, response);
     throw data("Conference not found", { status: 404 });
   }
 

--- a/frontend/app/routes/conferences.tsx
+++ b/frontend/app/routes/conferences.tsx
@@ -25,7 +25,7 @@ import {
 } from "~/components/ui/card";
 import MultipleSelector from "~/components/ui/multi-select";
 import { Switch } from "~/components/ui/switch";
-import { requireSession } from "~/lib/auth.server";
+import { logoutIfUnauthorized, requireSession } from "~/lib/auth.server";
 import { pickLabelTextColor } from "~/lib/color";
 import type { Route } from "./+types/conferences";
 
@@ -33,17 +33,27 @@ export async function loader({ request }: Route.LoaderArgs) {
   const { session, authHeaders } = await requireSession(request);
   const isSuperUser = session.get("isSuperUser") ?? false;
 
-  const { data: conferences, error } = await conferencesReadConferences({
+  const {
+    data: conferences,
+    error,
+    response,
+  } = await conferencesReadConferences({
     headers: authHeaders,
   });
   if (error) {
+    await logoutIfUnauthorized(session, response);
     throw data("Error fetching conferences", { status: 500 });
   }
 
-  const { data: tags, error: tagsError } = await tagsReadTags({
+  const {
+    data: tags,
+    error: tagsError,
+    response: tagsResponse,
+  } = await tagsReadTags({
     headers: authHeaders,
   });
   if (tagsError) {
+    await logoutIfUnauthorized(session, tagsResponse);
     throw data("Error fetching tags", { status: 500 });
   }
 

--- a/frontend/app/routes/create-tag.tsx
+++ b/frontend/app/routes/create-tag.tsx
@@ -1,7 +1,7 @@
 import { data, redirect } from "react-router";
 import type { TagCreate } from "~/client";
 import { tagsCreateTag } from "~/client";
-import { requireSession } from "~/lib/auth.server";
+import { logoutIfUnauthorized, requireSession } from "~/lib/auth.server";
 import type { Route } from "./+types/create-tag";
 
 // export async function loader({ request, params }: Route.LoaderArgs) {
@@ -20,7 +20,7 @@ import type { Route } from "./+types/create-tag";
 // }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { authHeaders } = await requireSession(request);
+  const { session, authHeaders } = await requireSession(request);
 
   const formData = await request.formData();
   const tagName = formData.get("name") as string;
@@ -31,11 +31,12 @@ export async function action({ request }: Route.ActionArgs) {
     color: tagColor ?? "#000000",
   };
 
-  const { error } = await tagsCreateTag({
+  const { error, response } = await tagsCreateTag({
     headers: authHeaders,
     body: tagCreate,
   });
   if (error) {
+    await logoutIfUnauthorized(session, response);
     throw data("Tag not found", { status: 404 });
   }
   return redirect("/settings");

--- a/frontend/app/routes/delete-tag.tsx
+++ b/frontend/app/routes/delete-tag.tsx
@@ -1,6 +1,6 @@
 import { data, redirect } from "react-router";
 import { tagsDeleteTag } from "~/client";
-import { requireSession } from "~/lib/auth.server";
+import { logoutIfUnauthorized, requireSession } from "~/lib/auth.server";
 import type { Route } from "./+types/delete-tag";
 
 // export async function loader({ request, params }: Route.LoaderArgs) {
@@ -19,13 +19,14 @@ import type { Route } from "./+types/delete-tag";
 // }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { authHeaders } = await requireSession(request);
+  const { session, authHeaders } = await requireSession(request);
 
-  const { error } = await tagsDeleteTag({
+  const { error, response } = await tagsDeleteTag({
     path: { tag_id: params.tagId },
     headers: authHeaders,
   });
   if (error) {
+    await logoutIfUnauthorized(session, response);
     throw data("Tag not found", { status: 404 });
   }
   return redirect("/settings");

--- a/frontend/app/routes/edit-conference.tsx
+++ b/frontend/app/routes/edit-conference.tsx
@@ -6,16 +6,21 @@ import { conferencesReadConference, conferencesUpdateConference } from "~/client
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
-import { requireSession } from "~/lib/auth.server";
+import { logoutIfUnauthorized, requireSession } from "~/lib/auth.server";
 import type { Route } from "./+types/edit-conference";
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { authHeaders } = await requireSession(request);
-  const { data: conference, error } = await conferencesReadConference({
+  const { session, authHeaders } = await requireSession(request);
+  const {
+    data: conference,
+    error,
+    response,
+  } = await conferencesReadConference({
     path: { conference_id: params.conferenceId },
     headers: authHeaders,
   });
   if (error) {
+    await logoutIfUnauthorized(session, response);
     throw data("Conference not found", { status: 404 });
   }
   return { conference };

--- a/frontend/app/routes/edit-tag.tsx
+++ b/frontend/app/routes/edit-tag.tsx
@@ -1,23 +1,28 @@
 import { data, redirect } from "react-router";
 import type { TagUpdate } from "~/client";
 import { tagsReadTag, tagsUpdateTag } from "~/client";
-import { requireSession } from "~/lib/auth.server";
+import { logoutIfUnauthorized, requireSession } from "~/lib/auth.server";
 import type { Route } from "./+types/edit-tag";
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { authHeaders } = await requireSession(request);
-  const { data: tag, error } = await tagsReadTag({
+  const { session, authHeaders } = await requireSession(request);
+  const {
+    data: tag,
+    error,
+    response,
+  } = await tagsReadTag({
     path: { tag_id: params.tagId },
     headers: authHeaders,
   });
   if (error) {
+    await logoutIfUnauthorized(session, response);
     throw data("Conference not found", { status: 404 });
   }
   return { tag };
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { authHeaders } = await requireSession(request);
+  const { session, authHeaders } = await requireSession(request);
   const formData = await request.formData();
   const tagName = formData.get("name") as string | null;
   const tagColor = formData.get("color") as string | null;
@@ -27,12 +32,13 @@ export async function action({ request, params }: Route.ActionArgs) {
     color: tagColor ?? undefined,
   };
 
-  const { error } = await tagsUpdateTag({
+  const { error, response } = await tagsUpdateTag({
     path: { tag_id: params.tagId },
     headers: authHeaders,
     body: tagUpdate,
   });
   if (error) {
+    await logoutIfUnauthorized(session, response);
     throw data("Tag not found", { status: 404 });
   }
   return redirect("/settings");

--- a/frontend/app/routes/settings.tsx
+++ b/frontend/app/routes/settings.tsx
@@ -25,7 +25,7 @@ import {
 } from "~/components/ui/dialog";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
-import { requireSession } from "~/lib/auth.server";
+import { logoutIfUnauthorized, requireSession } from "~/lib/auth.server";
 import { pickLabelTextColor } from "~/lib/color";
 import type { Route } from "./+types/settings";
 // User settings
@@ -35,35 +35,46 @@ import type { Route } from "./+types/settings";
 // - Change username
 
 export async function action({ request }: Route.ActionArgs) {
-  const { authHeaders } = await requireSession(request);
+  const { session, authHeaders } = await requireSession(request);
   const formData = await request.formData();
   const slackUserId = formData.get("slack_user_id") as string | null;
 
-  const { error } = await usersUpdateUserMe({
+  const { error, response } = await usersUpdateUserMe({
     headers: authHeaders,
     body: { slack_user_id: slackUserId || null },
   });
   if (error) {
+    await logoutIfUnauthorized(session, response);
     throw data("Failed to update profile", { status: 500 });
   }
   return redirect("/settings");
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { authHeaders } = await requireSession(request);
+  const { session, authHeaders } = await requireSession(request);
 
-  const { data: user, error: userError } = await usersReadUserMe({
+  const {
+    data: user,
+    error: userError,
+    response: userResponse,
+  } = await usersReadUserMe({
     headers: authHeaders,
   });
   if (userError || !user) {
-    throw data("User not found", { status: 404 });
+    await logoutIfUnauthorized(session, userResponse);
+    throw data("Error fetching user", { status: 500 });
   }
 
-  const { data: userTags, error: userTagsError } = await tagsReadTags({
+  const {
+    data: userTags,
+    error: userTagsError,
+    response: userTagsResponse,
+  } = await tagsReadTags({
     headers: authHeaders,
   });
   if (userTagsError || !userTags) {
-    throw data("User tags not found", { status: 404 });
+    await logoutIfUnauthorized(session, userTagsResponse);
+    throw data("Error fetching tags", { status: 500 });
   }
   return { user, userTags };
 }

--- a/frontend/app/routes/timeline.tsx
+++ b/frontend/app/routes/timeline.tsx
@@ -14,7 +14,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "~/components/ui/select";
-import { requireSession } from "~/lib/auth.server";
+import { logoutIfUnauthorized, requireSession } from "~/lib/auth.server";
 import { pickLabelTextColor } from "~/lib/color";
 import type { Route } from "./+types/timeline";
 
@@ -31,20 +31,30 @@ interface ScheduleItem {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { authHeaders } = await requireSession(request);
+  const { session, authHeaders } = await requireSession(request);
 
-  const { data: conferences, error } = await conferencesReadConferences({
+  const {
+    data: conferences,
+    error,
+    response,
+  } = await conferencesReadConferences({
     headers: authHeaders,
   });
   if (error) {
-    throw new Response("Error fetching conferences", { status: 500 });
+    await logoutIfUnauthorized(session, response);
+    throw data("Error fetching conferences", { status: 500 });
   }
 
-  const { data: userTags, error: userTagsError } = await tagsReadTags({
+  const {
+    data: userTags,
+    error: userTagsError,
+    response: userTagsResponse,
+  } = await tagsReadTags({
     headers: authHeaders,
   });
   if (userTagsError || !userTags) {
-    throw data("User tags not found", { status: 404 });
+    await logoutIfUnauthorized(session, userTagsResponse);
+    throw data("Error fetching tags", { status: 500 });
   }
 
   return { conferences, userTags };


### PR DESCRIPTION
The session cookie lives a year but the JWT only seven days, and
loaders only checked for the cookie: after a week away every page
threw a generic 500 with no path back to login. logoutIfUnauthorized
destroys the session and redirects to /login whenever the API answers
401 (expired/invalid token, deleted or disabled user); privilege
errors (403) still surface as errors. (Review item 3.1)

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 11 in a stack** made with GitButler:
- <kbd>&nbsp;11&nbsp;</kbd> #792 
- <kbd>&nbsp;10&nbsp;</kbd> #791 
- <kbd>&nbsp;9&nbsp;</kbd> #790 
- <kbd>&nbsp;8&nbsp;</kbd> #789 
- <kbd>&nbsp;7&nbsp;</kbd> #788 
- <kbd>&nbsp;6&nbsp;</kbd> #787 
- <kbd>&nbsp;5&nbsp;</kbd> #786 
- <kbd>&nbsp;4&nbsp;</kbd> #785 
- <kbd>&nbsp;3&nbsp;</kbd> #784 
- <kbd>&nbsp;2&nbsp;</kbd> #783 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #782 
<!-- GitButler Footer Boundary Bottom -->

