### PR TITLE
Do not commit the access token before it is verified

### DIFF
--- a/frontend/app/routes/login.tsx
+++ b/frontend/app/routes/login.tsx
@@ -44,14 +44,15 @@ export async function action({ request }: Route.ActionArgs) {
     });
   }
 
-  session.set("accessToken", data_.access_token);
-
   const { data: testTokenData, error: testTokenError } = await loginTestToken({
     headers: { Authorization: `Bearer ${data_.access_token}` },
   });
   if (testTokenError || !testTokenData) {
     session.flash("error", "Login failed");
 
+    // The token must not be in the session here: committing it would make
+    // the /login loader treat the user as logged in and bounce them to a
+    // broken /conferences.
     return redirect("/login", {
       headers: {
         "Set-Cookie": await commitSession(session),
@@ -59,6 +60,7 @@ export async function action({ request }: Route.ActionArgs) {
     });
   }
 
+  session.set("accessToken", data_.access_token);
   session.set("username", testTokenData.username);
   session.set("isSuperUser", testTokenData.is_superuser ?? false);
 


### PR DESCRIPTION
login set accessToken in the session before calling test-token; on
verification failure the redirect still committed the session, so the
/login loader saw a token and bounced the user straight to a broken
/conferences. Store the token only after verification succeeds.
(Review item 3.6)

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 11 in a stack** made with GitButler:
- <kbd>&nbsp;11&nbsp;</kbd> #792 
- <kbd>&nbsp;10&nbsp;</kbd> #791 
- <kbd>&nbsp;9&nbsp;</kbd> #790 
- <kbd>&nbsp;8&nbsp;</kbd> #789 
- <kbd>&nbsp;7&nbsp;</kbd> #788 
- <kbd>&nbsp;6&nbsp;</kbd> #787 
- <kbd>&nbsp;5&nbsp;</kbd> #786 
- <kbd>&nbsp;4&nbsp;</kbd> #785 
- <kbd>&nbsp;3&nbsp;</kbd> #784 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #783 
- <kbd>&nbsp;1&nbsp;</kbd> #782 
<!-- GitButler Footer Boundary Bottom -->

