### PR TITLE
Fall back to black text instead of throwing on invalid tag colors

### DIFF
--- a/frontend/app/lib/color.ts
+++ b/frontend/app/lib/color.ts
@@ -45,6 +45,10 @@ export function generateLabelBackground(textColor: string, ratio = 0.15): string
  * Return `"white"` or `"black"` depending on which gives better
  * WCAG-2.1 contrast against the supplied background color.
  *
+ * Invalid input falls back to `"black"`: this runs during render for
+ * user-supplied colors, so throwing would take down the whole route for
+ * a single malformed tag.
+ *
  * @param hex - Background color in `#RRGGBB`, `RRGGBB`, `#RGB`, or `RGB` form.
  */
 export function pickLabelTextColor(hex: string): "white" | "black" {
@@ -57,7 +61,7 @@ export function pickLabelTextColor(hex: string): "white" | "black" {
       .join("");
   }
   if (!/^[0-9a-f]{6}$/i.test(clean)) {
-    throw new Error(`Invalid hex color: ${hex}`);
+    return "black";
   }
 
   // ── 2. Parse to 0‒255 integers ───────────────────────────────


### PR DESCRIPTION
pickLabelTextColor threw for anything but 3/6-digit hex and is called
during render in conferences, timeline, and settings; one tag created
through the API with an arbitrary color string crashed those routes
into the error boundary. Server-side color validation is added
separately; the renderer must still tolerate legacy values.
(Review item 3.2)

<!-- GitButler Footer Boundary Top -->
---
This is **part 4 of 11 in a stack** made with GitButler:
- <kbd>&nbsp;11&nbsp;</kbd> #792 
- <kbd>&nbsp;10&nbsp;</kbd> #791 
- <kbd>&nbsp;9&nbsp;</kbd> #790 
- <kbd>&nbsp;8&nbsp;</kbd> #789 
- <kbd>&nbsp;7&nbsp;</kbd> #788 
- <kbd>&nbsp;6&nbsp;</kbd> #787 
- <kbd>&nbsp;5&nbsp;</kbd> #786 
- <kbd>&nbsp;4&nbsp;</kbd> #785 👈 
- <kbd>&nbsp;3&nbsp;</kbd> #784 
- <kbd>&nbsp;2&nbsp;</kbd> #783 
- <kbd>&nbsp;1&nbsp;</kbd> #782 
<!-- GitButler Footer Boundary Bottom -->

