### PR TITLE
Fix date-only handling: local-time parsing, no render mutation

### DIFF
--- a/frontend/app/lib/date.ts
+++ b/frontend/app/lib/date.ts
@@ -1,0 +1,45 @@
+/**
+ * Date-only helpers.
+ *
+ * API dates are date-only strings ("YYYY-MM-DD"). `new Date("YYYY-MM-DD")`
+ * parses as UTC midnight, so mixing it with local-time math (setHours,
+ * comparisons against `new Date()`) shifts dates by a day in timezones west
+ * of UTC. These helpers keep all calendar math in local time.
+ */
+
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+
+/** Parse a date-only string (or Date) into a Date at local midnight. */
+export function parseDateOnly(value: string | Date): Date {
+  if (value instanceof Date) {
+    const copy = new Date(value);
+    copy.setHours(0, 0, 0, 0);
+    return copy;
+  }
+  const [year = 1970, month = 1, day = 1] = value.slice(0, 10).split("-").map(Number);
+  return new Date(year, month - 1, day);
+}
+
+/** Today at local midnight. */
+export function startOfToday(): Date {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  return today;
+}
+
+/** Format a Date as its local YYYY-MM-DD. */
+export function formatDateOnly(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+/**
+ * Whole calendar days from `from` (default: today) to `to`.
+ * Positive means the future. Math.round absorbs DST-shortened/-lengthened
+ * days, so the result is consistent regardless of direction.
+ */
+export function diffCalendarDays(to: string | Date, from: string | Date = startOfToday()): number {
+  return Math.round((parseDateOnly(to).getTime() - parseDateOnly(from).getTime()) / MS_PER_DAY);
+}

--- a/frontend/app/routes/conferences.tsx
+++ b/frontend/app/routes/conferences.tsx
@@ -27,6 +27,7 @@ import MultipleSelector from "~/components/ui/multi-select";
 import { Switch } from "~/components/ui/switch";
 import { logoutIfUnauthorized, requireSession } from "~/lib/auth.server";
 import { pickLabelTextColor } from "~/lib/color";
+import { diffCalendarDays, parseDateOnly, startOfToday } from "~/lib/date";
 import type { Route } from "./+types/conferences";
 
 export async function loader({ request }: Route.LoaderArgs) {
@@ -61,13 +62,9 @@ export async function loader({ request }: Route.LoaderArgs) {
 }
 
 function isConferencePast(conference: ConferencePublic): boolean {
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
   const refDate = conference.end_date ?? conference.start_date;
   if (!refDate) return false;
-  const d = new Date(refDate);
-  d.setHours(0, 0, 0, 0);
-  return d < today;
+  return parseDateOnly(refDate) < startOfToday();
 }
 
 export default function Conferences({ loaderData }: Route.ComponentProps) {
@@ -83,8 +80,7 @@ export default function Conferences({ loaderData }: Route.ComponentProps) {
 
   const formatDate = (dateString?: string | null) => {
     if (!dateString) return "N/A";
-    const date = new Date(dateString);
-    return date.toISOString().slice(0, 10); // Format as YYYY-MM-DD
+    return dateString.slice(0, 10); // Already a date-only YYYY-MM-DD string
   };
 
   const formatDateTime = (dateString: string) => {
@@ -94,14 +90,7 @@ export default function Conferences({ loaderData }: Route.ComponentProps) {
 
   // Determine deadline status for styling
   const getDeadlineStatus = (deadlineString: string) => {
-    const deadline = new Date(deadlineString);
-    const today = new Date();
-
-    // Reset time part for accurate day calculation
-    deadline.setHours(0, 0, 0, 0);
-    today.setHours(0, 0, 0, 0);
-    const diffTime = deadline.getTime() - today.getTime();
-    const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+    const diffDays = diffCalendarDays(deadlineString);
 
     if (diffDays < 0) {
       return "text-zinc-500"; // Past deadline

--- a/frontend/app/routes/timeline.tsx
+++ b/frontend/app/routes/timeline.tsx
@@ -16,6 +16,7 @@ import {
 } from "~/components/ui/select";
 import { logoutIfUnauthorized, requireSession } from "~/lib/auth.server";
 import { pickLabelTextColor } from "~/lib/color";
+import { diffCalendarDays, formatDateOnly, parseDateOnly, startOfToday } from "~/lib/date";
 import type { Route } from "./+types/timeline";
 
 // Define the schedule item interface
@@ -66,18 +67,14 @@ export default function Timeline({ loaderData }: Route.ComponentProps) {
   const selectedTagId = searchParams.get("selectedTagId") ?? "_all";
   const showPast = searchParams.get("showPast") === "true";
 
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
+  const today = startOfToday();
 
   const scheduleItems: ScheduleItem[] = [];
+  // Renders the item's local calendar date plus its distance from today.
+  // Must not mutate its argument: it runs during render on loader data.
   const formatDate = (date: Date) => {
-    const dateString = date.toISOString().slice(0, 10); // Format as YYYY-MM-DD
-
-    const today = new Date();
-
-    date.setHours(0, 0, 0, 0); // Set time to midnight for comparison
-    today.setHours(0, 0, 0, 0); // Set time to midnight for comparison
-    const diffDays = Math.floor((date.getTime() - today.getTime()) / (1000 * 3600 * 24));
+    const dateString = formatDateOnly(date);
+    const diffDays = diffCalendarDays(date, today);
 
     const diffDaysText =
       diffDays === 0
@@ -87,7 +84,7 @@ export default function Timeline({ loaderData }: Route.ComponentProps) {
   };
   // Helper function to get month and year from date
   const getYearMonth = (date: Date): string => {
-    return date.toISOString().slice(0, 7); // Format as YYYY-MM
+    return formatDateOnly(date).slice(0, 7); // Format as YYYY-MM
   };
   conferences.data.forEach((conference) => {
     const conferenceTags = conference.tags ?? [];
@@ -95,7 +92,7 @@ export default function Timeline({ loaderData }: Route.ComponentProps) {
     if (selectedTagId === "_all" || conferenceTags.some((tag) => tag.id === selectedTagId)) {
       if (conference.start_date) {
         scheduleItems.push({
-          date: new Date(conference.start_date),
+          date: parseDateOnly(conference.start_date),
           type: "conference_start",
           title: `${conference.name} – Start`,
           tags: conferenceTags,
@@ -103,7 +100,7 @@ export default function Timeline({ loaderData }: Route.ComponentProps) {
       }
       if (conference.end_date) {
         scheduleItems.push({
-          date: new Date(conference.end_date),
+          date: parseDateOnly(conference.end_date),
           type: "conference_end",
           title: `${conference.name} – End`,
           tags: conferenceTags,
@@ -113,7 +110,7 @@ export default function Timeline({ loaderData }: Route.ComponentProps) {
         conference.milestones.forEach((milestone) => {
           if (milestone.date) {
             scheduleItems.push({
-              date: new Date(milestone.date),
+              date: parseDateOnly(milestone.date),
               type: "milestone",
               title: `${conference.name} – ${milestone.name}`,
               tags: conferenceTags,
@@ -213,12 +210,12 @@ export default function Timeline({ loaderData }: Route.ComponentProps) {
       </div>
       <div className="flex flex-col gap-4">
         {Object.entries(groupedScheduleItems).map(([yearMonth, items]) => {
-          const isAllPast = items.every((item) => item.date < new Date());
+          const isAllPast = items.every((item) => item.date < today);
           return (
             <div key={yearMonth} className="flex flex-col gap-2">
               <h2 className={`text-2xl font-bold ${isAllPast ? "opacity-50" : ""}`}>{yearMonth}</h2>
               {items.map((item) => {
-                const isPast = item.date < new Date();
+                const isPast = item.date < today;
                 return (
                   <Card
                     key={`${item.type}-${item.title}-${item.date.toISOString()}`}


### PR DESCRIPTION
- new Date('YYYY-MM-DD') parses UTC midnight; mixed with local-time
  setHours math, dates shifted a day west of UTC (conferences looked
  past a day early, deadline urgency off by one). parseDateOnly/
  formatDateOnly keep calendar math in local time.
- timeline's formatDate mutated item.date during render, so isPast/
  isAllPast changed between render passes. It now derives values
  without mutating.
- diffCalendarDays (Math.round on local midnights) replaces the
  Math.ceil vs Math.floor mismatch between the two pages.
(Review item 3.3)

<!-- GitButler Footer Boundary Top -->
---
This is **part 5 of 11 in a stack** made with GitButler:
- <kbd>&nbsp;11&nbsp;</kbd> #792 
- <kbd>&nbsp;10&nbsp;</kbd> #791 
- <kbd>&nbsp;9&nbsp;</kbd> #790 
- <kbd>&nbsp;8&nbsp;</kbd> #789 
- <kbd>&nbsp;7&nbsp;</kbd> #788 
- <kbd>&nbsp;6&nbsp;</kbd> #787 
- <kbd>&nbsp;5&nbsp;</kbd> #786 👈 
- <kbd>&nbsp;4&nbsp;</kbd> #785 
- <kbd>&nbsp;3&nbsp;</kbd> #784 
- <kbd>&nbsp;2&nbsp;</kbd> #783 
- <kbd>&nbsp;1&nbsp;</kbd> #782 
<!-- GitButler Footer Boundary Bottom -->

