### PR TITLE
Extract shared conference form parsing

### DIFF
--- a/frontend/app/lib/conference-form.ts
+++ b/frontend/app/lib/conference-form.ts
@@ -1,0 +1,43 @@
+import type { ConferenceCreate, ConferenceMilestoneCreate } from "~/client";
+
+/**
+ * Parse the create/edit conference form into a conference payload.
+ *
+ * Empty optional fields become null; milestone rows are collected from the
+ * indexed milestone_name__N / milestone_date__N inputs, skipping rows where
+ * either value is missing.
+ */
+export function parseConferenceForm(formData: FormData): ConferenceCreate {
+  const updates = Object.fromEntries(formData) as Record<string, string | null>;
+  // For fields other than name, set to null if empty
+  Object.keys(updates).forEach((field) => {
+    if (field !== "name" && updates[field] === "") {
+      updates[field] = null;
+    }
+  });
+
+  const milestoneIndices = Object.keys(updates)
+    .filter((key) => key.startsWith("milestone_name__"))
+    .map((key) => parseInt(key.split("__")[1], 10))
+    .filter((index) => updates[`milestone_name__${index}`] && updates[`milestone_date__${index}`]);
+
+  const milestones: ConferenceMilestoneCreate[] = milestoneIndices
+    .map((index): ConferenceMilestoneCreate | null => {
+      const name = updates[`milestone_name__${index}`];
+      const date = updates[`milestone_date__${index}`];
+      if (name == null || date == null) {
+        return null;
+      }
+      return { name, date };
+    })
+    .filter((milestone): milestone is ConferenceMilestoneCreate => milestone !== null);
+
+  return {
+    name: updates.name ?? "New Conference",
+    start_date: updates.start_date,
+    end_date: updates.end_date,
+    location: updates.location,
+    website_url: updates.website_url,
+    milestones: milestones,
+  };
+}

--- a/frontend/app/routes/create-conference.tsx
+++ b/frontend/app/routes/create-conference.tsx
@@ -1,51 +1,19 @@
 import { Trash2 } from "lucide-react";
 import { useId, useState } from "react";
 import { Form, redirect, useNavigate } from "react-router";
-import type { ConferenceCreate, ConferenceMilestoneCreate } from "~/client";
 import { conferencesCreateConference } from "~/client";
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
 import { requireSession } from "~/lib/auth.server";
+import { parseConferenceForm } from "~/lib/conference-form";
 import type { Route } from "./+types/create-conference";
 
 export async function action({ request }: Route.ActionArgs) {
   const { authHeaders } = await requireSession(request);
 
   const formData = await request.formData();
-  const updates = Object.fromEntries(formData) as Record<string, string | null>;
-  // For fields other than name, set to null if empty
-  Object.keys(updates).forEach((field) => {
-    if (field !== "name" && updates[field] === "") {
-      updates[field] = null;
-    }
-  });
-
-  // Extract the milestones fields from the form data
-  const milestoneIndices = Object.keys(updates)
-    .filter((key) => key.startsWith("milestone_name__"))
-    .map((key) => parseInt(key.split("__")[1], 10))
-    .filter((index) => updates[`milestone_name__${index}`] && updates[`milestone_date__${index}`]);
-
-  const milestones: ConferenceMilestoneCreate[] = milestoneIndices
-    .map((index): ConferenceMilestoneCreate | null => {
-      const name = updates[`milestone_name__${index}`];
-      const date = updates[`milestone_date__${index}`];
-      if (name == null || date == null) {
-        return null;
-      }
-      return { name, date };
-    })
-    .filter((milestone): milestone is ConferenceMilestoneCreate => milestone !== null);
-
-  const requestBody: ConferenceCreate = {
-    name: updates.name ?? "New Conference",
-    start_date: updates.start_date,
-    end_date: updates.end_date,
-    location: updates.location,
-    website_url: updates.website_url,
-    milestones: milestones,
-  };
+  const requestBody = parseConferenceForm(formData);
 
   await conferencesCreateConference({
     body: requestBody,

--- a/frontend/app/routes/edit-conference.tsx
+++ b/frontend/app/routes/edit-conference.tsx
@@ -1,12 +1,12 @@
 import { Trash2 } from "lucide-react";
 import { useId, useState } from "react";
 import { data, Form, redirect, useNavigate } from "react-router";
-import type { ConferenceCreate, ConferenceMilestoneCreate } from "~/client";
 import { conferencesReadConference, conferencesUpdateConference } from "~/client";
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
 import { logoutIfUnauthorized, requireSession } from "~/lib/auth.server";
+import { parseConferenceForm } from "~/lib/conference-form";
 import type { Route } from "./+types/edit-conference";
 
 export async function loader({ request, params }: Route.LoaderArgs) {
@@ -29,38 +29,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 export async function action({ request, params }: Route.ActionArgs) {
   const { authHeaders } = await requireSession(request);
   const formData = await request.formData();
-  const updates = Object.fromEntries(formData) as Record<string, string | null>;
-  // For fields other than name, set to null if empty
-  Object.keys(updates).forEach((field) => {
-    if (field !== "name" && updates[field] === "") {
-      updates[field] = null;
-    }
-  });
-
-  // Extract the milestones fields from the form data
-  const milestoneIndices = Object.keys(updates)
-    .filter((key) => key.startsWith("milestone_name__"))
-    .map((key) => parseInt(key.split("__")[1], 10))
-    .filter((index) => updates[`milestone_name__${index}`] && updates[`milestone_date__${index}`]);
-
-  const milestones: ConferenceMilestoneCreate[] = milestoneIndices
-    .map((index): ConferenceMilestoneCreate | null => {
-      const name = updates[`milestone_name__${index}`];
-      const date = updates[`milestone_date__${index}`];
-      if (name == null || date == null) {
-        return null;
-      }
-      return { name, date };
-    })
-    .filter((milestone): milestone is ConferenceMilestoneCreate => milestone !== null);
-  const requestBody: ConferenceCreate = {
-    name: updates.name ?? "New Conference",
-    start_date: updates.start_date,
-    end_date: updates.end_date,
-    location: updates.location,
-    website_url: updates.website_url,
-    milestones: milestones,
-  };
+  const requestBody = parseConferenceForm(formData);
 
   await conferencesUpdateConference({
     path: { conference_id: params.conferenceId },


### PR DESCRIPTION
create-conference and edit-conference duplicated ~40 identical lines
of milestone form parsing; parseConferenceForm is now the single
implementation. (Review section 4)

<!-- GitButler Footer Boundary Top -->
---
This is **part 6 of 11 in a stack** made with GitButler:
- <kbd>&nbsp;11&nbsp;</kbd> #792 
- <kbd>&nbsp;10&nbsp;</kbd> #791 
- <kbd>&nbsp;9&nbsp;</kbd> #790 
- <kbd>&nbsp;8&nbsp;</kbd> #789 
- <kbd>&nbsp;7&nbsp;</kbd> #788 
- <kbd>&nbsp;6&nbsp;</kbd> #787 👈 
- <kbd>&nbsp;5&nbsp;</kbd> #786 
- <kbd>&nbsp;4&nbsp;</kbd> #785 
- <kbd>&nbsp;3&nbsp;</kbd> #784 
- <kbd>&nbsp;2&nbsp;</kbd> #783 
- <kbd>&nbsp;1&nbsp;</kbd> #782 
<!-- GitButler Footer Boundary Bottom -->

