### PR TITLE
Surface API errors from conference write actions

### DIFF
--- a/frontend/app/lib/api.server.ts
+++ b/frontend/app/lib/api.server.ts
@@ -1,0 +1,16 @@
+/**
+ * Extract a human-readable message from an API error body, falling back to
+ * the given message. FastAPI errors carry a `detail` string (HTTPException)
+ * or a structured validation error we don't try to render.
+ */
+export function apiErrorMessage(error: unknown, fallback: string): string {
+  if (
+    error &&
+    typeof error === "object" &&
+    "detail" in error &&
+    typeof (error as { detail?: unknown }).detail === "string"
+  ) {
+    return (error as { detail: string }).detail;
+  }
+  return fallback;
+}

--- a/frontend/app/routes/create-conference.tsx
+++ b/frontend/app/routes/create-conference.tsx
@@ -1,28 +1,36 @@
 import { Trash2 } from "lucide-react";
 import { useId, useState } from "react";
-import { Form, redirect, useNavigate } from "react-router";
+import { data, Form, redirect, useNavigate } from "react-router";
 import { conferencesCreateConference } from "~/client";
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
-import { requireSession } from "~/lib/auth.server";
+import { apiErrorMessage } from "~/lib/api.server";
+import { logoutIfUnauthorized, requireSession } from "~/lib/auth.server";
 import { parseConferenceForm } from "~/lib/conference-form";
 import type { Route } from "./+types/create-conference";
 
 export async function action({ request }: Route.ActionArgs) {
-  const { authHeaders } = await requireSession(request);
+  const { session, authHeaders } = await requireSession(request);
 
   const formData = await request.formData();
   const requestBody = parseConferenceForm(formData);
 
-  await conferencesCreateConference({
+  const { error, response } = await conferencesCreateConference({
     body: requestBody,
     headers: authHeaders,
   });
+  if (error) {
+    await logoutIfUnauthorized(session, response);
+    return data(
+      { error: apiErrorMessage(error, "Failed to create the conference. Please try again.") },
+      { status: response?.status ?? 500 },
+    );
+  }
   return redirect(`/conferences`);
 }
 
-export default function CreateConference() {
+export default function CreateConference({ actionData }: Route.ComponentProps) {
   const navigate = useNavigate();
   // Generate unique IDs for form fields
   const formId = useId();
@@ -47,6 +55,7 @@ export default function CreateConference() {
   return (
     <Form id={formId} method="post">
       <div className="max-w-2xl mx-auto space-y-6">
+        {actionData?.error ? <div className="text-red-500">{actionData.error}</div> : null}
         <p className="text-sm text-yellow-600 mb-4">
           Conferences you create here will be shared and visible to all users.
           <br />

--- a/frontend/app/routes/delete-conference.tsx
+++ b/frontend/app/routes/delete-conference.tsx
@@ -1,17 +1,24 @@
 import { data, redirect } from "react-router";
 import { conferencesDeleteConference } from "~/client";
-import { requireSession } from "~/lib/auth.server";
+import { apiErrorMessage } from "~/lib/api.server";
+import { logoutIfUnauthorized, requireSession } from "~/lib/auth.server";
 import type { Route } from "./+types/delete-conference";
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { authHeaders } = await requireSession(request);
+  const { session, authHeaders } = await requireSession(request);
 
   if (!params.conferenceId) {
     throw data("Conference ID is required", { status: 400 });
   }
-  await conferencesDeleteConference({
+  const { error, response } = await conferencesDeleteConference({
     path: { conference_id: params.conferenceId },
     headers: authHeaders,
   });
+  if (error) {
+    await logoutIfUnauthorized(session, response);
+    throw data(apiErrorMessage(error, "Failed to delete the conference."), {
+      status: response?.status ?? 500,
+    });
+  }
   return redirect("/conferences");
 }

--- a/frontend/app/routes/edit-conference.tsx
+++ b/frontend/app/routes/edit-conference.tsx
@@ -5,6 +5,7 @@ import { conferencesReadConference, conferencesUpdateConference } from "~/client
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
+import { apiErrorMessage } from "~/lib/api.server";
 import { logoutIfUnauthorized, requireSession } from "~/lib/auth.server";
 import { parseConferenceForm } from "~/lib/conference-form";
 import type { Route } from "./+types/edit-conference";
@@ -27,19 +28,26 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { authHeaders } = await requireSession(request);
+  const { session, authHeaders } = await requireSession(request);
   const formData = await request.formData();
   const requestBody = parseConferenceForm(formData);
 
-  await conferencesUpdateConference({
+  const { error, response } = await conferencesUpdateConference({
     path: { conference_id: params.conferenceId },
     body: requestBody,
     headers: authHeaders,
   });
+  if (error) {
+    await logoutIfUnauthorized(session, response);
+    return data(
+      { error: apiErrorMessage(error, "Failed to save the conference. Please try again.") },
+      { status: response?.status ?? 500 },
+    );
+  }
   return redirect(`/conferences`);
 }
 
-export default function EditConference({ loaderData }: Route.ComponentProps) {
+export default function EditConference({ loaderData, actionData }: Route.ComponentProps) {
   const { conference } = loaderData;
   const navigate = useNavigate();
   const formId = useId();
@@ -54,6 +62,7 @@ export default function EditConference({ loaderData }: Route.ComponentProps) {
   return (
     <Form key={conference.id} id={formId} method="post">
       <div className="max-w-2xl mx-auto space-y-6">
+        {actionData?.error ? <div className="text-red-500">{actionData.error}</div> : null}
         <p className="text-sm text-yellow-600 mb-4">
           Changes made here are shared and will affect all users.
           <br />


### PR DESCRIPTION
create/edit/delete-conference awaited the API call without checking
error, then redirected: a failed save (validation, expired token, 500)
silently returned the user to the list as if it had succeeded. Create
and edit now render the API error above the form; delete propagates a
real error response. All three log out on 401. (Review item 3.4)

<!-- GitButler Footer Boundary Top -->
---
This is **part 7 of 11 in a stack** made with GitButler:
- <kbd>&nbsp;11&nbsp;</kbd> #792 
- <kbd>&nbsp;10&nbsp;</kbd> #791 
- <kbd>&nbsp;9&nbsp;</kbd> #790 
- <kbd>&nbsp;8&nbsp;</kbd> #789 
- <kbd>&nbsp;7&nbsp;</kbd> #788 👈 
- <kbd>&nbsp;6&nbsp;</kbd> #787 
- <kbd>&nbsp;5&nbsp;</kbd> #786 
- <kbd>&nbsp;4&nbsp;</kbd> #785 
- <kbd>&nbsp;3&nbsp;</kbd> #784 
- <kbd>&nbsp;2&nbsp;</kbd> #783 
- <kbd>&nbsp;1&nbsp;</kbd> #782 
<!-- GitButler Footer Boundary Bottom -->

