### PR TITLE
Fix smaller frontend issues from the code review

### DIFF
--- a/frontend/app/layouts/main-frame.tsx
+++ b/frontend/app/layouts/main-frame.tsx
@@ -1,5 +1,5 @@
 import { NavLink, useNavigate } from "react-router";
-import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
+import { Avatar, AvatarFallback } from "~/components/ui/avatar";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -62,7 +62,6 @@ export function MainFrame({
                 <DropdownMenu>
                   <DropdownMenuTrigger className="flex items-center space-x-2">
                     <Avatar className="w-8 h-8">
-                      <AvatarImage src="/path/to/avatar.jpg" alt="User Avatar" />
                       <AvatarFallback>{username.charAt(0)}</AvatarFallback>
                     </Avatar>
                     <span className="text-zinc-600">{username}</span>

--- a/frontend/app/layouts/main.tsx
+++ b/frontend/app/layouts/main.tsx
@@ -38,8 +38,13 @@ export function ErrorBoundary({ error, loaderData }: Route.ErrorBoundaryProps) {
       <div>
         <h1>Error</h1>
         <p>{error.message}</p>
-        <p>The stack trace is:</p>
-        <pre>{error.stack}</pre>
+        {/* Stack traces must not leak in production builds */}
+        {import.meta.env.DEV && error.stack ? (
+          <>
+            <p>The stack trace is:</p>
+            <pre>{error.stack}</pre>
+          </>
+        ) : null}
       </div>
     );
   } else {

--- a/frontend/app/lib/api.server.ts
+++ b/frontend/app/lib/api.server.ts
@@ -1,3 +1,59 @@
+import type { ConferencePublic, TagPublic } from "~/client";
+import { conferencesReadConferences, tagsReadTags } from "~/client";
+
+/** Page size for list endpoints; the backend clamps limit to at most 100. */
+const PAGE_LIMIT = 100;
+
+interface FetchAllResult<T> {
+  data?: { data: T[]; count: number };
+  error?: unknown;
+  response?: Response;
+}
+
+/**
+ * Fetch every page of the conferences list. A single request returns at
+ * most 100 rows, so without paging the 101st conference silently
+ * disappears while count still reports the true total.
+ */
+export async function fetchAllConferences(headers: {
+  Authorization: string;
+}): Promise<FetchAllResult<ConferencePublic>> {
+  const all: ConferencePublic[] = [];
+  for (let skip = 0; ; skip += PAGE_LIMIT) {
+    const { data, error, response } = await conferencesReadConferences({
+      headers,
+      query: { skip, limit: PAGE_LIMIT },
+    });
+    if (error || !data) {
+      return { error, response };
+    }
+    all.push(...data.data);
+    if (all.length >= data.count || data.data.length === 0) {
+      return { data: { data: all, count: all.length }, response };
+    }
+  }
+}
+
+/** Fetch every page of the current user's tags. */
+export async function fetchAllTags(headers: {
+  Authorization: string;
+}): Promise<FetchAllResult<TagPublic>> {
+  const all: TagPublic[] = [];
+  for (let skip = 0; ; skip += PAGE_LIMIT) {
+    const { data, error, response } = await tagsReadTags({
+      headers,
+      query: { skip, limit: PAGE_LIMIT },
+    });
+    if (error || !data) {
+      return { error, response };
+    }
+    all.push(...data.data);
+    if (all.length >= data.count || data.data.length === 0) {
+      return { data: { data: all, count: all.length }, response };
+    }
+  }
+}
+
 /**
  * Extract a human-readable message from an API error body, falling back to
  * the given message. FastAPI errors carry a `detail` string (HTTPException)

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -65,8 +65,13 @@ export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
       <div>
         <h1>Error</h1>
         <p>{error.message}</p>
-        <p>The stack trace is:</p>
-        <pre>{error.stack}</pre>
+        {/* Stack traces must not leak in production builds */}
+        {import.meta.env.DEV && error.stack ? (
+          <>
+            <p>The stack trace is:</p>
+            <pre>{error.stack}</pre>
+          </>
+        ) : null}
       </div>
     );
   } else {

--- a/frontend/app/routes/conference-tags.tsx
+++ b/frontend/app/routes/conference-tags.tsx
@@ -8,7 +8,13 @@ export async function action({ request, params }: Route.ActionArgs) {
   const { session, authHeaders } = await requireSession(request);
 
   const formData = await request.formData();
-  const tags = JSON.parse(formData.get("tags") as string) as Option[];
+  let tags: Option[];
+  try {
+    tags = JSON.parse(formData.get("tags") as string) as Option[];
+  } catch {
+    // Client-supplied form data; malformed JSON is a bad request, not a 500.
+    throw data("Invalid tags payload", { status: 400 });
+  }
 
   if (!params.conferenceId) {
     throw data("Conference ID is required", { status: 400 });

--- a/frontend/app/routes/conferences.tsx
+++ b/frontend/app/routes/conferences.tsx
@@ -1,7 +1,6 @@
 import { Bell, BellOff, Calendar, MapPin, Pencil, Plus, Trash2 } from "lucide-react";
 import { data, Form, useSearchParams, useSubmit } from "react-router";
 import type { ConferencePublic } from "~/client";
-import { conferencesReadConferences, tagsReadTags } from "~/client";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -25,6 +24,7 @@ import {
 } from "~/components/ui/card";
 import MultipleSelector from "~/components/ui/multi-select";
 import { Switch } from "~/components/ui/switch";
+import { fetchAllConferences, fetchAllTags } from "~/lib/api.server";
 import { logoutIfUnauthorized, requireSession } from "~/lib/auth.server";
 import { pickLabelTextColor } from "~/lib/color";
 import { diffCalendarDays, parseDateOnly, startOfToday } from "~/lib/date";
@@ -34,26 +34,14 @@ export async function loader({ request }: Route.LoaderArgs) {
   const { session, authHeaders } = await requireSession(request);
   const isSuperUser = session.get("isSuperUser") ?? false;
 
-  const {
-    data: conferences,
-    error,
-    response,
-  } = await conferencesReadConferences({
-    headers: authHeaders,
-  });
-  if (error) {
+  const { data: conferences, error, response } = await fetchAllConferences(authHeaders);
+  if (error || !conferences) {
     await logoutIfUnauthorized(session, response);
     throw data("Error fetching conferences", { status: 500 });
   }
 
-  const {
-    data: tags,
-    error: tagsError,
-    response: tagsResponse,
-  } = await tagsReadTags({
-    headers: authHeaders,
-  });
-  if (tagsError) {
+  const { data: tags, error: tagsError, response: tagsResponse } = await fetchAllTags(authHeaders);
+  if (tagsError || !tags) {
     await logoutIfUnauthorized(session, tagsResponse);
     throw data("Error fetching tags", { status: 500 });
   }
@@ -152,11 +140,11 @@ export default function Conferences({ loaderData }: Route.ComponentProps) {
                 <CardDescription>
                   <div className="text-sm text-gray-500 space-y-1">
                     <div className="flex items-center">
-                      <MapPin className="w-4 h-4 mr-1 shrink-0" area-hidden="true" />
+                      <MapPin className="w-4 h-4 mr-1 shrink-0" aria-hidden="true" />
                       {conference.location}
                     </div>
                     <div className="flex items-center">
-                      <Calendar className="w-4 h-4 mr-1 shrink-0" area-hidden="true" />
+                      <Calendar className="w-4 h-4 mr-1 shrink-0" aria-hidden="true" />
                       {formatDateRange(conference.start_date, conference.end_date)}
                     </div>
                   </div>
@@ -167,10 +155,10 @@ export default function Conferences({ loaderData }: Route.ComponentProps) {
                 {conference.milestones && conference.milestones.length > 0 ? (
                   <ul className="list-disc list-inside">
                     {conference.milestones
-                      .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
+                      .toSorted((a, b) => a.date.localeCompare(b.date))
                       .map((milestone) => (
                         <li
-                          key={`${milestone.name}-${milestone.date}`}
+                          key={milestone.id}
                           className={`${getDeadlineStatus(milestone.date)} text-sm`}
                         >
                           {milestone.name}: {formatDate(milestone.date)}

--- a/frontend/app/routes/create-conference.tsx
+++ b/frontend/app/routes/create-conference.tsx
@@ -69,6 +69,7 @@ export default function CreateConference({ actionData }: Route.ComponentProps) {
             type="text"
             placeholder="Conference Name"
             defaultValue="New Conference"
+            required
           />
         </div>
         <div className="space-y-1">

--- a/frontend/app/routes/create-tag.tsx
+++ b/frontend/app/routes/create-tag.tsx
@@ -37,7 +37,7 @@ export async function action({ request }: Route.ActionArgs) {
   });
   if (error) {
     await logoutIfUnauthorized(session, response);
-    throw data("Tag not found", { status: 404 });
+    throw data("Failed to create the tag", { status: response?.status ?? 500 });
   }
   return redirect("/settings");
 }

--- a/frontend/app/routes/edit-conference.tsx
+++ b/frontend/app/routes/edit-conference.tsx
@@ -77,6 +77,7 @@ export default function EditConference({ loaderData, actionData }: Route.Compone
             type="text"
             defaultValue={conference.name}
             placeholder="Conference Name"
+            required
           />
         </div>
         <div className="space-y-1">

--- a/frontend/app/routes/edit-tag.tsx
+++ b/frontend/app/routes/edit-tag.tsx
@@ -16,7 +16,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   });
   if (error) {
     await logoutIfUnauthorized(session, response);
-    throw data("Conference not found", { status: 404 });
+    throw data("Tag not found", { status: 404 });
   }
   return { tag };
 }

--- a/frontend/app/routes/login.tsx
+++ b/frontend/app/routes/login.tsx
@@ -83,11 +83,17 @@ export default function Login({ loaderData }: Route.ComponentProps) {
       <Form method="post">
         <div className="mb-4">
           <Label htmlFor={usernameId}>Username</Label>
-          <Input type="username" id={usernameId} name="username" required />
+          <Input type="text" autoComplete="username" id={usernameId} name="username" required />
         </div>
         <div className="mb-4">
           <Label htmlFor={passwordId}>Password</Label>
-          <Input type="password" id={passwordId} name="password" required />
+          <Input
+            type="password"
+            autoComplete="current-password"
+            id={passwordId}
+            name="password"
+            required
+          />
         </div>
         <Button type="submit">Login</Button>
       </Form>

--- a/frontend/app/routes/register.tsx
+++ b/frontend/app/routes/register.tsx
@@ -1,6 +1,7 @@
 import { useId } from "react";
 import { data, redirect, useFetcher } from "react-router";
 import { usersRegisterUser } from "~/client";
+import { apiErrorMessage } from "~/lib/api.server";
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
@@ -28,7 +29,7 @@ export async function action({ request }: Route.ActionArgs) {
     return data({ errors }, { status: 400 });
   }
 
-  const { error } = await usersRegisterUser({
+  const { error, response } = await usersRegisterUser({
     body: {
       username: username,
       password: password,
@@ -36,10 +37,10 @@ export async function action({ request }: Route.ActionArgs) {
   });
 
   if (error) {
-    return data({
-      errors: { general: "username already exists" },
-      status: 400,
-    });
+    return data(
+      { errors: { general: apiErrorMessage(error, "Registration failed") } },
+      { status: response?.status ?? 400 },
+    );
   }
 
   return redirect("/login");
@@ -58,11 +59,17 @@ export default function Register(_: Route.ComponentProps) {
       <fetcher.Form method="post">
         <div className="mb-4">
           <Label htmlFor={usernameId}>Username</Label>
-          <Input type="username" id={usernameId} name="username" required />
+          <Input type="text" autoComplete="username" id={usernameId} name="username" required />
         </div>
         <div className="mb-4">
           <Label htmlFor={passwordId}>Password</Label>
-          <Input type="password" id={passwordId} name="password" required />
+          <Input
+            type="password"
+            autoComplete="new-password"
+            id={passwordId}
+            name="password"
+            required
+          />
         </div>
         <div className="mb-4">
           <Label htmlFor={confirmPasswordId}>Confirm Password</Label>

--- a/frontend/app/routes/settings.tsx
+++ b/frontend/app/routes/settings.tsx
@@ -1,7 +1,7 @@
 import { Plus, Trash2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { data, Form, redirect, useNavigation } from "react-router";
-import { tagsReadTags, usersReadUserMe, usersUpdateUserMe } from "~/client";
+import { usersReadUserMe, usersUpdateUserMe } from "~/client";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -25,6 +25,7 @@ import {
 } from "~/components/ui/dialog";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
+import { fetchAllTags } from "~/lib/api.server";
 import { logoutIfUnauthorized, requireSession } from "~/lib/auth.server";
 import { pickLabelTextColor } from "~/lib/color";
 import type { Route } from "./+types/settings";
@@ -69,9 +70,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     data: userTags,
     error: userTagsError,
     response: userTagsResponse,
-  } = await tagsReadTags({
-    headers: authHeaders,
-  });
+  } = await fetchAllTags(authHeaders);
   if (userTagsError || !userTags) {
     await logoutIfUnauthorized(session, userTagsResponse);
     throw data("Error fetching tags", { status: 500 });

--- a/frontend/app/routes/timeline.tsx
+++ b/frontend/app/routes/timeline.tsx
@@ -1,6 +1,6 @@
 import { Calendar } from "lucide-react";
 import { data, useSearchParams } from "react-router";
-import { conferencesReadConferences, tagsReadTags } from "~/client";
+import { fetchAllConferences, fetchAllTags } from "~/lib/api.server";
 import { Badge } from "~/components/ui/badge";
 import { Card, CardDescription, CardFooter, CardHeader, CardTitle } from "~/components/ui/card";
 import { Label } from "~/components/ui/label";
@@ -34,14 +34,8 @@ interface ScheduleItem {
 export async function loader({ request }: Route.LoaderArgs) {
   const { session, authHeaders } = await requireSession(request);
 
-  const {
-    data: conferences,
-    error,
-    response,
-  } = await conferencesReadConferences({
-    headers: authHeaders,
-  });
-  if (error) {
+  const { data: conferences, error, response } = await fetchAllConferences(authHeaders);
+  if (error || !conferences) {
     await logoutIfUnauthorized(session, response);
     throw data("Error fetching conferences", { status: 500 });
   }
@@ -50,9 +44,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     data: userTags,
     error: userTagsError,
     response: userTagsResponse,
-  } = await tagsReadTags({
-    headers: authHeaders,
-  });
+  } = await fetchAllTags(authHeaders);
   if (userTagsError || !userTags) {
     await logoutIfUnauthorized(session, userTagsResponse);
     throw data("Error fetching tags", { status: 500 });

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "include": ["**/*", "**/.server/**/*", "**/.client/**/*", ".react-router/types/**/*"],
   "compilerOptions": {
-    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "lib": ["DOM", "DOM.Iterable", "ES2023"],
     "types": ["node", "vite/client"],
     "target": "ES2022",
     "module": "ES2022",


### PR DESCRIPTION
- register: put the 400 in ResponseInit instead of the payload (the
  response was a 200), and show the API's actual error message.
- Gate error-boundary stack traces behind import.meta.env.DEV in
  root.tsx and layouts/main.tsx.
- conferences: aria-hidden (was area-hidden), toSorted() instead of
  mutating loader data during render, milestone.id as list key.
- Fetch all pages of conferences/tags in loaders; the backend caps
  limit at 100, so the 101st row silently disappeared.
- Correct copy-pasted tag error messages; JSON.parse of client form
  data now returns 400 instead of crashing; conference name inputs are
  required (backend also rejects empty names now).
- login/register: type=text with proper autocomplete instead of the
  invalid type=username.
- Remove the placeholder AvatarImage that requested a nonexistent
  asset on every page. (Review item 3.7)

<!-- GitButler Footer Boundary Top -->
---
This is **part 9 of 11 in a stack** made with GitButler:
- <kbd>&nbsp;11&nbsp;</kbd> #792 
- <kbd>&nbsp;10&nbsp;</kbd> #791 
- <kbd>&nbsp;9&nbsp;</kbd> #790 👈 
- <kbd>&nbsp;8&nbsp;</kbd> #789 
- <kbd>&nbsp;7&nbsp;</kbd> #788 
- <kbd>&nbsp;6&nbsp;</kbd> #787 
- <kbd>&nbsp;5&nbsp;</kbd> #786 
- <kbd>&nbsp;4&nbsp;</kbd> #785 
- <kbd>&nbsp;3&nbsp;</kbd> #784 
- <kbd>&nbsp;2&nbsp;</kbd> #783 
- <kbd>&nbsp;1&nbsp;</kbd> #782 
<!-- GitButler Footer Boundary Bottom -->

