### PR TITLE
Remove commented-out dead code

### DIFF
--- a/frontend/app/routes/create-tag.tsx
+++ b/frontend/app/routes/create-tag.tsx
@@ -4,21 +4,6 @@ import { tagsCreateTag } from "~/client";
 import { logoutIfUnauthorized, requireSession } from "~/lib/auth.server";
 import type { Route } from "./+types/create-tag";
 
-// export async function loader({ request, params }: Route.LoaderArgs) {
-//   const session = await getSession(request.headers.get("Cookie"));
-//   if (!session.has("accessToken")) {
-//     return redirect("/login");
-//   }
-//   const { data: tag, error } = await tagsReadTag({
-//     path: { tag_id: params.tagId },
-//     headers: { Authorization: `Bearer ${session.get("accessToken")}` },
-//   });
-//   if (error) {
-//     throw data("Conference not found", { status: 404 });
-//   }
-//   return { tag };
-// }
-
 export async function action({ request }: Route.ActionArgs) {
   const { session, authHeaders } = await requireSession(request);
 

--- a/frontend/app/routes/delete-tag.tsx
+++ b/frontend/app/routes/delete-tag.tsx
@@ -3,21 +3,6 @@ import { tagsDeleteTag } from "~/client";
 import { logoutIfUnauthorized, requireSession } from "~/lib/auth.server";
 import type { Route } from "./+types/delete-tag";
 
-// export async function loader({ request, params }: Route.LoaderArgs) {
-//   const session = await getSession(request.headers.get("Cookie"));
-//   if (!session.has("accessToken")) {
-//     return redirect("/login");
-//   }
-//   const { data: tag, error } = await tagsReadTag({
-//     path: { tag_id: params.tagId },
-//     headers: { Authorization: `Bearer ${session.get("accessToken")}` },
-//   });
-//   if (error) {
-//     throw data("Conference not found", { status: 404 });
-//   }
-//   return { tag };
-// }
-
 export async function action({ request, params }: Route.ActionArgs) {
   const { session, authHeaders } = await requireSession(request);
 

--- a/frontend/app/routes/settings.tsx
+++ b/frontend/app/routes/settings.tsx
@@ -104,7 +104,6 @@ function TagDialog({
   /** Setter to change the open dialog id. */
   setOpenTagId: React.Dispatch<React.SetStateAction<string | null>>;
 }) {
-  // const [open, setOpen] = useState(false);
   const [name, setName] = useState(tag.name);
   const [color, setColor] = useState(tag.color);
 


### PR DESCRIPTION
Deletes the commented-out template loaders in create-tag and
delete-tag and a leftover useState line in settings; the backend's
commented-out remnants were removed with the auth cleanup.
(Review section 4)

<!-- GitButler Footer Boundary Top -->
---
This is **part 10 of 11 in a stack** made with GitButler:
- <kbd>&nbsp;11&nbsp;</kbd> #792 
- <kbd>&nbsp;10&nbsp;</kbd> #791 👈 
- <kbd>&nbsp;9&nbsp;</kbd> #790 
- <kbd>&nbsp;8&nbsp;</kbd> #789 
- <kbd>&nbsp;7&nbsp;</kbd> #788 
- <kbd>&nbsp;6&nbsp;</kbd> #787 
- <kbd>&nbsp;5&nbsp;</kbd> #786 
- <kbd>&nbsp;4&nbsp;</kbd> #785 
- <kbd>&nbsp;3&nbsp;</kbd> #784 
- <kbd>&nbsp;2&nbsp;</kbd> #783 
- <kbd>&nbsp;1&nbsp;</kbd> #782 
<!-- GitButler Footer Boundary Bottom -->

