### PR TITLE
Add a frontend Vitest suite and CI job

### DIFF
--- a/.github/workflows/lint-frontend.yaml
+++ b/.github/workflows/lint-frontend.yaml
@@ -86,8 +86,23 @@ jobs:
       - name: Build the frontend
         run: pnpm run build
 
+  vp-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup Vite+
+        uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
+        with:
+          working-directory: frontend
+          cache: true
+
+      - name: Run Vite+ tests
+        run: vp test
+
   collect-lint-frontend:
-    needs: [vp-check, typecheck, build]
+    needs: [vp-check, typecheck, build, vp-test]
     runs-on: ubuntu-latest
     steps:
       - name: Collect results

--- a/frontend/app/lib/color.test.ts
+++ b/frontend/app/lib/color.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "vite-plus/test";
+import { generateLabelBackground, hexToRgb, pickLabelTextColor, rgbToHex } from "./color";
+
+describe("pickLabelTextColor", () => {
+  test.each([
+    ["#000000", "white"],
+    ["#ffffff", "black"],
+    ["#0f0", "black"],
+    ["1e3a8a", "white"],
+  ])("picks the higher-contrast text color for %s", (background, expected) => {
+    expect(pickLabelTextColor(background)).toBe(expected);
+  });
+
+  test.each(["red", "", "#12345", "#gggggg", "not a color"])(
+    "falls back to black instead of throwing for invalid input %j",
+    (background) => {
+      expect(pickLabelTextColor(background)).toBe("black");
+    },
+  );
+});
+
+describe("hexToRgb / rgbToHex", () => {
+  test("round-trips a 6-digit color", () => {
+    expect(hexToRgb("#1e90ff")).toEqual([30, 144, 255]);
+    expect(rgbToHex(30, 144, 255)).toBe("#1e90ff");
+  });
+
+  test("expands 3-digit colors", () => {
+    expect(hexToRgb("#0f0")).toEqual([0, 255, 0]);
+  });
+});
+
+describe("generateLabelBackground", () => {
+  test("blends toward white", () => {
+    expect(generateLabelBackground("#000000", 0)).toBe("#ffffff");
+    expect(generateLabelBackground("#000000", 1)).toBe("#000000");
+  });
+
+  test("returns the input when empty", () => {
+    expect(generateLabelBackground("")).toBe("");
+  });
+});

--- a/frontend/app/lib/conference-form.test.ts
+++ b/frontend/app/lib/conference-form.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "vite-plus/test";
+import { parseConferenceForm } from "./conference-form";
+
+function makeFormData(entries: Record<string, string>): FormData {
+  const formData = new FormData();
+  for (const [key, value] of Object.entries(entries)) {
+    formData.append(key, value);
+  }
+  return formData;
+}
+
+describe("parseConferenceForm", () => {
+  test("nulls empty optional fields but keeps the name", () => {
+    const parsed = parseConferenceForm(
+      makeFormData({
+        name: "ISTS 2027",
+        start_date: "",
+        end_date: "2027-06-05",
+        location: "",
+        website_url: "",
+      }),
+    );
+    expect(parsed.name).toBe("ISTS 2027");
+    expect(parsed.start_date).toBeNull();
+    expect(parsed.end_date).toBe("2027-06-05");
+    expect(parsed.location).toBeNull();
+    expect(parsed.website_url).toBeNull();
+    expect(parsed.milestones).toEqual([]);
+  });
+
+  test("collects milestone rows with id and time", () => {
+    const parsed = parseConferenceForm(
+      makeFormData({
+        name: "ISTS 2027",
+        milestone_id__0: "11111111-1111-1111-1111-111111111111",
+        milestone_name__0: "Abstract deadline",
+        milestone_date__0: "2027-01-15",
+        milestone_time__0: "12:00",
+        milestone_id__2: "",
+        milestone_name__2: "Camera-ready",
+        milestone_date__2: "2027-03-01",
+        milestone_time__2: "",
+      }),
+    );
+    expect(parsed.milestones).toEqual([
+      {
+        id: "11111111-1111-1111-1111-111111111111",
+        name: "Abstract deadline",
+        date: "2027-01-15",
+        time: "12:00",
+      },
+      // New rows have no id; a cleared time is sent as null.
+      { id: undefined, name: "Camera-ready", date: "2027-03-01", time: null },
+    ]);
+  });
+
+  test("skips milestone rows missing a name or date", () => {
+    const parsed = parseConferenceForm(
+      makeFormData({
+        name: "ISTS 2027",
+        milestone_name__0: "Incomplete",
+        milestone_date__0: "",
+        milestone_name__1: "",
+        milestone_date__1: "2027-01-15",
+      }),
+    );
+    expect(parsed.milestones).toEqual([]);
+  });
+});

--- a/frontend/app/lib/date.test.ts
+++ b/frontend/app/lib/date.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "vite-plus/test";
+import { diffCalendarDays, formatDateOnly, parseDateOnly, startOfToday } from "./date";
+
+describe("parseDateOnly", () => {
+  test("parses a date-only string into local midnight", () => {
+    const date = parseDateOnly("2027-06-01");
+    expect(date.getFullYear()).toBe(2027);
+    expect(date.getMonth()).toBe(5);
+    expect(date.getDate()).toBe(1);
+    expect(date.getHours()).toBe(0);
+    expect(date.getMinutes()).toBe(0);
+  });
+
+  test("copies a Date without mutating the original", () => {
+    const original = new Date(2027, 5, 1, 15, 30);
+    const parsed = parseDateOnly(original);
+    expect(parsed.getHours()).toBe(0);
+    expect(original.getHours()).toBe(15);
+  });
+});
+
+describe("formatDateOnly", () => {
+  test("formats the local calendar date", () => {
+    expect(formatDateOnly(new Date(2027, 0, 5))).toBe("2027-01-05");
+  });
+
+  test("round-trips with parseDateOnly", () => {
+    expect(formatDateOnly(parseDateOnly("2027-12-31"))).toBe("2027-12-31");
+  });
+});
+
+describe("diffCalendarDays", () => {
+  test.each([
+    ["2027-06-02", "2027-06-01", 1],
+    ["2027-06-01", "2027-06-01", 0],
+    ["2027-05-30", "2027-06-01", -2],
+    ["2028-06-01", "2027-06-01", 366], // 2028 is a leap year
+  ])("from %s to %s is %i days", (to, from, expected) => {
+    expect(diffCalendarDays(to, from)).toBe(expected);
+  });
+
+  test("defaults to counting from today", () => {
+    expect(diffCalendarDays(startOfToday())).toBe(0);
+  });
+});


### PR DESCRIPTION
Covers the pure libraries extracted while fixing the review findings:
color contrast picking with the invalid-input fallback, local-time
date-only parsing/formatting/diffing, and conference form parsing
including milestone ids and times. Adds a vp test job to the frontend
CI workflow; previously CI only linted. (Review section 4)

<!-- GitButler Footer Boundary Top -->
---
This is **part 11 of 11 in a stack** made with GitButler:
- <kbd>&nbsp;11&nbsp;</kbd> #792 👈 
- <kbd>&nbsp;10&nbsp;</kbd> #791 
- <kbd>&nbsp;9&nbsp;</kbd> #790 
- <kbd>&nbsp;8&nbsp;</kbd> #789 
- <kbd>&nbsp;7&nbsp;</kbd> #788 
- <kbd>&nbsp;6&nbsp;</kbd> #787 
- <kbd>&nbsp;5&nbsp;</kbd> #786 
- <kbd>&nbsp;4&nbsp;</kbd> #785 
- <kbd>&nbsp;3&nbsp;</kbd> #784 
- <kbd>&nbsp;2&nbsp;</kbd> #783 
- <kbd>&nbsp;1&nbsp;</kbd> #782 
<!-- GitButler Footer Boundary Bottom -->

