### PR TITLE
Create user and credential in a single transaction

### DIFF
--- a/backend/src/scholark/auth/db_provider.py
+++ b/backend/src/scholark/auth/db_provider.py
@@ -1,3 +1,4 @@
+from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session, select
 
 from scholark.core.security import get_password_hash, verify_password
@@ -26,23 +27,24 @@ class DbAuthProvider(AuthProvider):
         # Set default tags for the user
         new_user.tags.extend(default_tags(user_id=new_user.id))
 
-        self.db.add(new_user)
-
-        try:
-            self.db.commit()
-        except Exception as e:
-            self.db.rollback()
-            raise AuthProviderError(status_code=500, detail="Database error") from e
-
-        hashed_password = get_password_hash(user_create.password)
         new_cred = DbAuthCredential(
             user_id=new_user.id,
-            hashed_password=hashed_password,
+            hashed_password=get_password_hash(user_create.password),
         )
-        self.db.add(new_cred)
 
+        # One transaction: committing the user without its credential would
+        # strand a username that exists but can never authenticate.
+        self.db.add(new_user)
         try:
+            # Flush the user row first so the credential's FK target exists;
+            # there is no ORM relationship between the two, so SQLAlchemy
+            # cannot order the inserts on its own. flush() does not commit.
+            self.db.flush()
+            self.db.add(new_cred)
             self.db.commit()
+        except IntegrityError as e:
+            self.db.rollback()
+            raise AuthProviderError(status_code=400, detail="User already exists") from e
         except Exception as e:
             self.db.rollback()
             raise AuthProviderError(status_code=500, detail="Database error") from e


### PR DESCRIPTION
create_user committed the User row and the DbAuthCredential row in two
separate commits. A failure between them stranded a credential-less
user: the username was permanently taken but could never log in.
Insert both in one transaction, mapping a duplicate-username race to
400 instead of 500. (Review item 2.2)

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 7 in a stack** made with GitButler:
- <kbd>&nbsp;7&nbsp;</kbd> #781 
- <kbd>&nbsp;6&nbsp;</kbd> #780 
- <kbd>&nbsp;5&nbsp;</kbd> #779 
- <kbd>&nbsp;4&nbsp;</kbd> #778 
- <kbd>&nbsp;3&nbsp;</kbd> #777 
- <kbd>&nbsp;2&nbsp;</kbd> #796 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #795 
<!-- GitButler Footer Boundary Bottom -->

