### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scholark"
-version = "0"
+version = "0.2.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1173,7 +1173,7 @@ wheels = [
 
 [[package]]
 name = "scholark"
-version = "0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary
- Bump Scholark package version to 0.2.0
- Refresh backend uv lockfile

## Tests
- `just lint-backend`
- `cd backend && uv lock --check && uv run pytest`