### PR TITLE
Freeze pre-commit hook revisions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,11 @@
+ci:
+  autoupdate_schedule: monthly
+  autofix_prs: false
+
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.15.20
+    rev: c59bba8fb259db0fec2bbb77ad8ba51ea7341b56  # frozen: v0.15.20
     hooks:
       # Run the linter.
       - id: ruff
@@ -9,7 +13,7 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -35,7 +39,7 @@ repos:
 
   - repo: https://github.com/astral-sh/uv-pre-commit
     # uv version.
-    rev: 0.11.26
+    rev: b1b0a3ca3d67a225af2a0a786f939e8a6381aa3a  # frozen: 0.11.27
     hooks:
       - id: uv-lock
         files: backend/pyproject.toml


### PR DESCRIPTION
## Summary
- freeze pre-commit hook revisions to immutable SHAs
- configure pre-commit.ci monthly autoupdates with autofix PRs disabled

Tests not run (not requested).